### PR TITLE
Add collections argument to Photo#random.

### DIFF
--- a/lib/unsplash/photo.rb
+++ b/lib/unsplash/photo.rb
@@ -45,9 +45,10 @@ module Unsplash # :nodoc:
       # @param width [Integer] Width of customized version of the photo.
       # @param height [Integer] Height of the customized version of the photo.
       # @return [Unsplash::Photo] An Unsplash Photo.
-      def random(categories: nil, featured: nil, user: nil, query: nil, width: nil, height: nil)
+      def random(categories: nil, collections: nil, featured: nil, user: nil, query: nil, width: nil, height: nil)
         params = {
           category: (categories && categories.join(",")),
+          collections: (collections && collections.join(",")),
           featured: featured,
           username: user,
           query:    query,

--- a/spec/lib/photo_spec.rb
+++ b/spec/lib/photo_spec.rb
@@ -76,6 +76,17 @@ describe Unsplash::Photo do
       end
     end
 
+    context "with collections" do
+      it "joins them" do
+        expect(Unsplash::Photo.connection)
+          .to receive(:get).with("/photos/random", collections: "4,5,6")
+          .and_return double(body: "{}")
+
+        photo = Unsplash::Photo.random(collections: [4,5,6])
+      end
+    end
+
+
     context "without categories" do
       it "removes them" do
         expect(Unsplash::Photo.connection)


### PR DESCRIPTION
The API random endpoint accepts a comma-separated list of collection ID's to select the photo from. Add support for this.