### PR TITLE
Log response Warning headers.

### DIFF
--- a/lib/unsplash/configuration.rb
+++ b/lib/unsplash/configuration.rb
@@ -3,10 +3,12 @@ module Unsplash # :nodoc:
     attr_accessor :application_id
     attr_accessor :application_secret
     attr_accessor :application_redirect_uri
+    attr_accessor :logger
     attr_writer   :test
 
     def initialize
       @test = true
+      @logger = Logger.new(STDOUT)
     end
 
     def test?

--- a/lib/unsplash/connection.rb
+++ b/lib/unsplash/connection.rb
@@ -93,8 +93,12 @@ module Unsplash #:nodoc:
         param_key = verb == :post ? :body : :params
         @oauth_token.public_send(verb,  @api_base_uri + path, param_key => params, headers: headers)
       
-      else        
+      else
         self.class.public_send verb, path, query: params, headers: public_auth_header
+      end
+
+      if response.headers["Warning"]
+        Unsplash.configuration.logger.warn response.headers["Warning"]
       end
 
       status_code = response.respond_to?(:status) ? response.status : response.code

--- a/spec/unsplash_spec.rb
+++ b/spec/unsplash_spec.rb
@@ -4,4 +4,12 @@ describe Unsplash do
   it 'has a version number' do
     expect(Unsplash::VERSION).not_to be nil
   end
+
+  it "logs warning response headers" do
+    response = double(body: "[]", status: 200, headers: { "Warning" => "Watch out!" })
+    allow(Unsplash::Connection).to receive(:get).and_return(response)
+
+    expect(Unsplash.configuration.logger).to receive(:warn).with("Watch out!")
+    Unsplash::CuratedBatch.all
+  end
 end


### PR DESCRIPTION
For deprecated endpoints, the API returns a `Warning` http header with a message describing the deprecation. Log those (by default to stdout).