### PR TITLE
Add curated endpoint

### DIFF
--- a/lib/unsplash/photo.rb
+++ b/lib/unsplash/photo.rb
@@ -86,6 +86,20 @@ module Unsplash # :nodoc:
         parse_list connection.get("/photos/", params).body
       end
 
+      # Get a single page from the list of the curated photos (front-page’s photos).
+      # @param page [Integer] Which page of search results to return.
+      # @param per_page [Integer] The number of search results per page.
+      # @param order_by [String] How to sort the photos.
+      # @return [Array] A single page of +Unsplash::Photo+ search results.
+      def curated(page = 1, per_page = 10, order_by = "popular")
+        params = {
+          page:     page,
+          per_page: per_page,
+          order_by: order_by
+        }
+        parse_list connection.get("/photos/curated", params).body
+      end
+
       # Upload a photo on behalf of the current user.
       # @param filepath [String] The local path of the image file to upload.
       # @return [Unsplash::Photo] The uploaded photo.

--- a/spec/cassettes/photos.yml
+++ b/spec/cassettes/photos.yml
@@ -586,4 +586,76 @@ http_interactions:
       string: '{"errors":["OAuth error: The access token is invalid"]}'
     http_version: 
   recorded_at: Tue, 20 Oct 2015 15:33:06 GMT
+- request:
+    method: get
+    uri: http://api.lvh.me:3000/photos/curated?order_by=popular&page=1&per_page=6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Client-ID baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Link,X-Total,X-Per-Page,X-RateLimit-Limit,X-RateLimit-Remaining
+      Link:
+      - <http://api.lvh.me:3000/photos/curated?order_by=popular&page=108&per_page=6>;
+        rel="last", <http://api.lvh.me:3000/photos/curated?order_by=popular&page=2&per_page=6>;
+        rel="next"
+      X-Total:
+      - '1080'
+      X-Per-Page:
+      - '6'
+      Cache-Control:
+      - max-age=300, public
+      Content-Type:
+      - application/json
+      Etag:
+      - W/"a4c8ad200f672b87cb0dee3dd562c6d1"
+      X-Request-Id:
+      - c7f1c4d6-033f-4993-9bc5-1d745e2ea637
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '98'
+      X-Runtime:
+      - '0.113694'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      - 1.1 vegur
+      Content-Length:
+      - '24066'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 21 Jun 2016 22:44:02 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-ams4135-AMS
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '[{"id":"esm80lpf2kE","urls":{"regular":"https://ununsplash.imgix.net/photo-1433116209692-9330d85f1afb?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=639d0f9069b778709d219781497f2268","small":"https://ununsplash.imgix.net/photo-1433116209692-9330d85f1afb?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=5619ece8766efd2bbaa3eb18521138ce","thumb":"https://ununsplash.imgix.net/photo-1433116209692-9330d85f1afb?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=a3ff5ea821f38e86daab7f9569d657b5"},"links":{"self":"http://api.lvh.me:3000/photos/esm80lpf2kE","html":"http://lvh.me:3000/photos/esm80lpf2kE","download":"http://lvh.me:3000/photos/esm80lpf2kE/download"}},{"id":"bUsIoLKTk18","urls":{"regular":"https://unsplash.imgix.net/photo-1433100325891-378af68b3b8e?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=6d8a4dfeb744406f080c535afc01c65b","small":"https://unsplash.imgix.net/photo-1433100325891-378af68b3b8e?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=a89c66d2342239b76dd5de2776cdde86","thumb":"https://unsplash.imgix.net/photo-1433100325891-378af68b3b8e?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=b8d118a9ab354492259988d5e6811f94"},"links":{"self":"http://api.lvh.me:3000/photos/bUsIoLKTk18","html":"http://lvh.me:3000/photos/bUsIoLKTk18","download":"http://lvh.me:3000/photos/bUsIoLKTk18/download"}},{"id":"OVRxj5h6n7o","urls":{"regular":"https://ununsplash.imgix.net/photo-1433094657682-205abd5f883b?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=7ab44e3617f1b122758155343b35a29b","small":"https://ununsplash.imgix.net/photo-1433094657682-205abd5f883b?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=d38ee958dad8a8390c015ab1765004a0","thumb":"https://ununsplash.imgix.net/photo-1433094657682-205abd5f883b?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=b4a97c22b3463303394c8f77d6f760d4"},"links":{"self":"http://api.lvh.me:3000/photos/OVRxj5h6n7o","html":"http://lvh.me:3000/photos/OVRxj5h6n7o","download":"http://lvh.me:3000/photos/OVRxj5h6n7o/download"}},{"id":"KGRZFB1U25I","urls":{"regular":"https://ununsplash.imgix.net/photo-1433093833773-10e0c78a401b?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=38e144963a4a1dfc6c68692550bf9b04","small":"https://ununsplash.imgix.net/photo-1433093833773-10e0c78a401b?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=476ab6101647ac45786915537b199327","thumb":"https://ununsplash.imgix.net/photo-1433093833773-10e0c78a401b?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=315b37cf4dee17879d9016f6b026c826"},"links":{"self":"http://api.lvh.me:3000/photos/KGRZFB1U25I","html":"http://lvh.me:3000/photos/KGRZFB1U25I","download":"http://lvh.me:3000/photos/KGRZFB1U25I/download"}},{"id":"8CCQ-55MTUw","urls":{"regular":"https://unsplash.imgix.net/photo-1433087870301-b85d84efc18a?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=72ba2c921b8d50bda6fd64a4a8310ef8","small":"https://unsplash.imgix.net/photo-1433087870301-b85d84efc18a?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=55a324883b24065a21c4cdc0c8877d90","thumb":"https://unsplash.imgix.net/photo-1433087870301-b85d84efc18a?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=a79f21313ff22e1532ee0f4203a9603c"},"links":{"self":"http://api.lvh.me:3000/photos/8CCQ-55MTUw","html":"http://lvh.me:3000/photos/8CCQ-55MTUw","download":"http://lvh.me:3000/photos/8CCQ-55MTUw/download"}},{"id":"0Ebrm0d-G_E","urls":{"regular":"https://unsplash.imgix.net/photo-1433087639215-37846ea63501?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=4452fdb5f2afef59a7678c27bb6a86d5","small":"https://unsplash.imgix.net/photo-1433087639215-37846ea63501?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=9bd804a341ae0b704d453288543f0c0f","thumb":"https://unsplash.imgix.net/photo-1433087639215-37846ea63501?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=95450ed3f84177040e7395b8d324cbe6"},"links":{"self":"http://api.lvh.me:3000/photos/0Ebrm0d-G_E","html":"http://lvh.me:3000/photos/0Ebrm0d-G_E","download":"http://lvh.me:3000/photos/0Ebrm0d-G_E/download"}}]'
+    http_version:
+  recorded_at: Tue, 21 Jun 2016 22:44:03 GMT
 recorded_with: VCR 2.9.3

--- a/spec/lib/photo_spec.rb
+++ b/spec/lib/photo_spec.rb
@@ -121,6 +121,17 @@ describe Unsplash::Photo do
     end
   end
 
+  describe "#curated" do
+    it "returns an array of Photos" do
+      VCR.use_cassette("photos") do
+        @photos = Unsplash::Photo.curated(1, 6)
+      end
+
+      expect(@photos).to be_an Array
+      expect(@photos.size).to eq 6
+    end
+  end
+
   describe "#create" do
     let (:filepath) {  }
 


### PR DESCRIPTION
This PR adds a new method to access `/photos/curated` endpoint as described [here](https://unsplash.com/documentation).

``` ruby
Unsplash::Photo.curated
```