### PR TITLE
Per page param

### DIFF
--- a/lib/unsplash/collection.rb
+++ b/lib/unsplash/collection.rb
@@ -15,7 +15,7 @@ module Unsplash # :nodoc:
 
       # Get a list of all collections.
       # @param page [Integer] Which page of search results to return.
-      # @param per_page [Integer] The number of search results per page.
+      # @param per_page [Integer] The number of search results per page. (default: 10, maximum: 30)
       # @return [Array] A single page of the +Unsplash::Collection+ list.
       def all(page = 1, per_page = 10)
         params = {
@@ -28,7 +28,7 @@ module Unsplash # :nodoc:
 
       # Get a list of all curated collections.
       # @param page [Integer] Which page of search results to return.
-      # @param per_page [Integer] The number of search results per page.
+      # @param per_page [Integer] The number of search results per page. (default: 10, maximum: 30)
       # @return [Array] A single page of the +Unsplash::Collection+ list.
       def curated(page = 1, per_page = 10)
         params = {
@@ -55,11 +55,13 @@ module Unsplash # :nodoc:
       # Get a single page of collection results for a query.
       # @param query [String] Keywords to search for.
       # @param page  [Integer] Which page of search results to return.
+      # @param per_page [Integer] The number of collections search result per page. (default: 10, maximum: 30)
       # @return [Array] a list of +Unsplash::Collection+ objects. 
-      def search(query, page = 1)
+      def search(query, page = 1, per_page = 10)
         params = {
           query:    query,
-          page:     page
+          page:     page,
+          per_page: per_page
         }
         Unsplash::Search.search("/search/collections", self, params)
       end
@@ -96,6 +98,8 @@ module Unsplash # :nodoc:
     end
 
     # Get a list of the photos contained in this collection.
+    # @param page [Integer] Which page of photos collection to return.
+    # @param per_page [Integer] The number of photos per page. (default: 10, maximum: 30)
     # @return [Array] The list of +Unsplash::Photo+s in the collection.
     def photos(page = 1, per_page = 10)
       params = {

--- a/lib/unsplash/photo.rb
+++ b/lib/unsplash/photo.rb
@@ -62,7 +62,7 @@ module Unsplash # :nodoc:
         if count
           params[:count] = count
           photos = parse_list connection.get("/photos/random/", params).body
-          photos.map { |photo| 
+          photos.map { |photo|
             photo.user = Unsplash::User.new photo[:user]
             photo
           }
@@ -76,17 +76,20 @@ module Unsplash # :nodoc:
       # Search for photos by keyword.
       # @param query [String] Keywords to search for.
       # @param page  [Integer] Which page of search results to return.
-      def search(query, page = 1)
+      # @param per_page [Integer] The number of users search result per page. (default: 10, maximum: 30)
+      # @return [Array] a list of +Unsplash::Photo+ objects.
+      def search(query, page = 1, per_page = 10)
         params = {
           query:    query,
-          page:     page
+          page:     page,
+          per_page: per_page
         }
         Unsplash::Search.search("/search/photos", self, params)
       end
 
       # Get a list of all photos.
       # @param page  [Integer] Which page of search results to return.
-      # @param per_page [Integer] The number of search results per page.
+      # @param per_page [Integer] The number of search results per page. (default: 10, maximum: 30)
       # @return [Array] A single page of +Unsplash::Photo+ search results.
       def all(page = 1, per_page = 10)
         params = {
@@ -98,7 +101,7 @@ module Unsplash # :nodoc:
 
       # Get a single page from the list of the curated photos (front-page’s photos).
       # @param page [Integer] Which page of search results to return.
-      # @param per_page [Integer] The number of search results per page.
+      # @param per_page [Integer] The number of search results per page. (default: 10, maximum: 30)
       # @param order_by [String] How to sort the photos.
       # @return [Array] A single page of +Unsplash::Photo+ search results.
       def curated(page = 1, per_page = 10, order_by = "popular")

--- a/lib/unsplash/user.rb
+++ b/lib/unsplash/user.rb
@@ -28,11 +28,13 @@ module Unsplash # nodoc:
       # Get a single page of user results for a query.
       # @param query [String] Keywords to search for.
       # @param page  [Integer] Which page of search results to return.
+      # @param per_page [Integer] The number of users search result per page. (default: 10, maximum: 30)
       # @return [Array] a list of +Unsplash::User+ objects.
-      def search(query, page = 1)
+      def search(query, page = 1, per_page = 10)
         params = {
           query:    query,
-          page:     page
+          page:     page,
+          per_page: per_page
         }
         Unsplash::Search.search("/search/users", self, params)
       end
@@ -57,7 +59,7 @@ module Unsplash # nodoc:
 
     # Get a list of photos liked by the user.
     # @param page  [Integer] Which page of results to return.
-    # @param per_page [Integer] The number of results per page.
+    # @param per_page [Integer] The number of results per page. (default: 10, maximum: 30)
     # @return [Array] a list of +Unsplash::Photo+ objects.
     def likes(page = 1, per_page = 10)
       params = {
@@ -73,7 +75,7 @@ module Unsplash # nodoc:
 
     # Get a list of collections created by the user.
     # @param page  [Integer] Which page of results to return.
-    # @param per_page [Integer] The number of results per page.
+    # @param per_page [Integer] The number of results per page. (default: 10, maximum: 30)
     # @return [Array] a list of +Unsplash::Collection+ objects.
     def collections(page = 1, per_page = 10)
       params = {
@@ -88,5 +90,4 @@ module Unsplash # nodoc:
     end
 
   end
-
 end

--- a/spec/cassettes/collections.yml
+++ b/spec/cassettes/collections.yml
@@ -911,7 +911,7 @@ http_interactions:
   recorded_at: Mon, 11 Apr 2016 20:41:21 GMT
 - request:
     method: get
-    uri: http://api.lvh.me:3000/search/collections?page=1&query=explore
+    uri: http://api.lvh.me:3000/search/collections?page=1&per_page=10&query=explore
     body:
       encoding: US-ASCII
       string: ''
@@ -962,7 +962,7 @@ http_interactions:
   recorded_at: Mon, 11 Apr 2016 17:54:49 GMT
 - request:
     method: get
-    uri: http://api.lvh.me:3000/search/collections?page=1&query=veryveryspecific
+    uri: http://api.lvh.me:3000/search/collections?page=1&per_page=10&query=veryveryspecific
     body:
       encoding: US-ASCII
       string: ''
@@ -1007,6 +1007,60 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"total":1,"total_pages":1,"results":[]}'
+    http_version:
+  recorded_at: Mon, 11 Apr 2016 17:54:49 GMT
+- request:
+    method: get
+    uri: http://api.lvh.me:3000/search/collections?page=1&per_page=2&query=explore
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Client-ID baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Link,X-Total,X-Per-Page,X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - must-revalidate, private, max-age=0
+      Content-Type:
+      - application/json
+      Etag:
+      - W/"d5d32fd7f45a292e2bc4a08125330024"
+      X-Request-Id:
+      - de15dff4-1f3d-48a2-93ca-9d6849c31d79
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '98'
+      X-Runtime:
+      - '0.094648'
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      - __profilin=p%3Dt; path=/
+      - __profilin=p%3Dt; path=/
+      X-Miniprofiler-Ids:
+      - '["85qlnh0mnvecgq0q3glt","w9ijlts0ho1zswwwsjbn","qk5n3yagrfu4nh2qyt7y"]'
+      Content-Length:
+      - '3364'
+    body:
+      encoding: UTF-8
+      string: '{"total":2,"total_pages":1,"results":[{"id":201,"title":"Explore Iceland","published_at":"2015-12-30T16:56:29-05:00","curated":false,"cover_photo":{"id":"uO4Au3LrCtk","width":3000,"height":2000,"color":"#565B63","likes":0,"liked_by_user":false,"user":{"id":"46rKBE69V4I","username":"andersjilden","name":"Anders
+        Jildén","profile_image":{"small":"https://images.unsplash.com/profile-1444219778067-a301067fdc5e?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=32\u0026w=32\u0026s=d78a65a5e29c45cdb790895d0587bafe","medium":"https://images.unsplash.com/profile-1444219778067-a301067fdc5e?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=64\u0026w=64\u0026s=e041071e984375a0f2ed01d340a3aa00","large":"https://images.unsplash.com/profile-1444219778067-a301067fdc5e?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=128\u0026w=128\u0026s=8c6a75b3379366defac8399dc8f30221"},"links":{"self":"http://api.lvh.me:3000/users/andersjilden","html":"http://lvh.me:3000/andersjilden","photos":"http://api.lvh.me:3000/users/andersjilden/photos","likes":"http://api.lvh.me:3000/users/andersjilden/likes"}},"urls":{"raw":"https://images.unsplash.com/photo-1445503058969-7ae8721cd8c1","full":"https://images.unsplash.com/photo-1445503058969-7ae8721cd8c1?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=entropy\u0026s=75f81eef4dddc6d740a6903e0bef4dab","regular":"https://images.unsplash.com/photo-1445503058969-7ae8721cd8c1?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=entropy\u0026w=1080\u0026fit=max\u0026s=7e069062d4af1ffc5f5a80107cf4302b","small":"https://images.unsplash.com/photo-1445503058969-7ae8721cd8c1?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=entropy\u0026w=400\u0026fit=max\u0026s=ed45724e0b45053f46eccf9f6927cbd5","thumb":"https://images.unsplash.com/photo-1445503058969-7ae8721cd8c1?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=entropy\u0026w=200\u0026fit=max\u0026s=40cf57127d49d8114fbc8bb22254a3ce"},"categories":[{"id":4,"title":"Nature","photo_count":31454,"links":{"self":"http://api.lvh.me:3000/categories/4","photos":"http://api.lvh.me:3000/categories/4/photos"}}],"links":{"self":"http://api.lvh.me:3000/photos/uO4Au3LrCtk","html":"http://lvh.me:3000/photos/uO4Au3LrCtk","download":"http://lvh.me:3000/photos/uO4Au3LrCtk/download"}},"user":{"id":"QV5S1rtoUJ0","username":"unsplash","name":"Unsplash","bio":"Make
+        something awesome.","profile_image":{"small":"https://images.unsplash.com/profile-1441945026710-480e4372a5b5?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=32\u0026w=32\u0026s=15dd677c95172edff29e9b7a3be052c1","medium":"https://images.unsplash.com/profile-1441945026710-480e4372a5b5?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=64\u0026w=64\u0026s=7ae2265df9881ef927465a3215b4de94","large":"https://images.unsplash.com/profile-1441945026710-480e4372a5b5?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=128\u0026w=128\u0026s=96b07acf064bb8ba33e257c9391b440a"},"links":{"self":"http://api.lvh.me:3000/users/unsplash","html":"http://lvh.me:3000/unsplash","photos":"http://api.lvh.me:3000/users/unsplash/photos","likes":"http://api.lvh.me:3000/users/unsplash/likes"}},"links":{"self":"http://api.lvh.me:3000/collections/201","html":"http://lvh.me:3000/collections/201","photos":"http://api.lvh.me:3000/collections/201/photos"}},
+        {"id":201,"title":"Explore Iceland","published_at":"2015-12-30T16:56:29-05:00","curated":false,"cover_photo":{"id":"uO4Au3LrCtk","width":3000,"height":2000,"color":"#565B63","likes":0,"liked_by_user":false,"user":{"id":"46rKBE69V4I","username":"andersjilden","name":"Anders
+        Jildén","profile_image":{"small":"https://images.unsplash.com/profile-1444219778067-a301067fdc5e?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=32\u0026w=32\u0026s=d78a65a5e29c45cdb790895d0587bafe","medium":"https://images.unsplash.com/profile-1444219778067-a301067fdc5e?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=64\u0026w=64\u0026s=e041071e984375a0f2ed01d340a3aa00","large":"https://images.unsplash.com/profile-1444219778067-a301067fdc5e?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=128\u0026w=128\u0026s=8c6a75b3379366defac8399dc8f30221"},"links":{"self":"http://api.lvh.me:3000/users/andersjilden","html":"http://lvh.me:3000/andersjilden","photos":"http://api.lvh.me:3000/users/andersjilden/photos","likes":"http://api.lvh.me:3000/users/andersjilden/likes"}},"urls":{"raw":"https://images.unsplash.com/photo-1445503058969-7ae8721cd8c1","full":"https://images.unsplash.com/photo-1445503058969-7ae8721cd8c1?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=entropy\u0026s=75f81eef4dddc6d740a6903e0bef4dab","regular":"https://images.unsplash.com/photo-1445503058969-7ae8721cd8c1?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=entropy\u0026w=1080\u0026fit=max\u0026s=7e069062d4af1ffc5f5a80107cf4302b","small":"https://images.unsplash.com/photo-1445503058969-7ae8721cd8c1?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=entropy\u0026w=400\u0026fit=max\u0026s=ed45724e0b45053f46eccf9f6927cbd5","thumb":"https://images.unsplash.com/photo-1445503058969-7ae8721cd8c1?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=entropy\u0026w=200\u0026fit=max\u0026s=40cf57127d49d8114fbc8bb22254a3ce"},"categories":[{"id":4,"title":"Nature","photo_count":31454,"links":{"self":"http://api.lvh.me:3000/categories/4","photos":"http://api.lvh.me:3000/categories/4/photos"}}],"links":{"self":"http://api.lvh.me:3000/photos/uO4Au3LrCtk","html":"http://lvh.me:3000/photos/uO4Au3LrCtk","download":"http://lvh.me:3000/photos/uO4Au3LrCtk/download"}},"user":{"id":"QV5S1rtoUJ0","username":"unsplash","name":"Unsplash","bio":"Make
+        something awesome.","profile_image":{"small":"https://images.unsplash.com/profile-1441945026710-480e4372a5b5?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=32\u0026w=32\u0026s=15dd677c95172edff29e9b7a3be052c1","medium":"https://images.unsplash.com/profile-1441945026710-480e4372a5b5?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=64\u0026w=64\u0026s=7ae2265df9881ef927465a3215b4de94","large":"https://images.unsplash.com/profile-1441945026710-480e4372a5b5?ixlib=rb-0.3.5\u0026q=80\u0026fm=jpg\u0026crop=faces\u0026fit=crop\u0026h=128\u0026w=128\u0026s=96b07acf064bb8ba33e257c9391b440a"},"links":{"self":"http://api.lvh.me:3000/users/unsplash","html":"http://lvh.me:3000/unsplash","photos":"http://api.lvh.me:3000/users/unsplash/photos","likes":"http://api.lvh.me:3000/users/unsplash/likes"}},"links":{"self":"http://api.lvh.me:3000/collections/201","html":"http://lvh.me:3000/collections/201","photos":"http://api.lvh.me:3000/collections/201/photos"}}]}'
     http_version:
   recorded_at: Mon, 11 Apr 2016 17:54:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/photos.yml
+++ b/spec/cassettes/photos.yml
@@ -143,7 +143,7 @@ http_interactions:
   recorded_at: Mon, 22 Jun 2015 19:34:34 GMT
 - request:
     method: get
-    uri: http://api.lvh.me:3000/search/photos?page=1&query=dog
+    uri: http://api.lvh.me:3000/search/photos?page=1&per_page=10&query=dog
     body:
       encoding: US-ASCII
       string: ''
@@ -191,6 +191,58 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"total":10,"total_pages":1,"results":[{"id":"J75SjdIvfoE","urls":{"regular":"https://ununsplash.imgix.net/photo-1424915950309-955546acf037?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=a2020e053595b065e3de1a794afe0c83","small":"https://ununsplash.imgix.net/photo-1424915950309-955546acf037?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=cba622b6ac52c5f799e9468b270df4da","thumb":"https://ununsplash.imgix.net/photo-1424915950309-955546acf037?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=3c7bb86ec4a19901d5b2d1141eaa4511"},"links":{"self":"http://api.lvh.me:3000/photos/J75SjdIvfoE","html":"http://lvh.me:3000/photos/J75SjdIvfoE","download":"http://lvh.me:3000/photos/J75SjdIvfoE/download"}},{"id":"Fu8pblIzEL0","urls":{"regular":"https://unsplash.imgix.net/photo-1425678013935-cafcfb4272c7?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=d9aeec038e349aeaf3179be303118ace","small":"https://unsplash.imgix.net/photo-1425678013935-cafcfb4272c7?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=c0fe3331e74a24705cdfe34444590ccd","thumb":"https://unsplash.imgix.net/photo-1425678013935-cafcfb4272c7?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=441c557a1af327596ff6f141ae653585"},"links":{"self":"http://api.lvh.me:3000/photos/Fu8pblIzEL0","html":"http://lvh.me:3000/photos/Fu8pblIzEL0","download":"http://lvh.me:3000/photos/Fu8pblIzEL0/download"}},{"id":"pChE-f_gqVc","urls":{"regular":"https://unsplash.imgix.net/photo-1426287658398-5a912ce1ed0a?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=252911cdb2fcb31be15811568e36d4f6","small":"https://unsplash.imgix.net/photo-1426287658398-5a912ce1ed0a?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=e672f02cb4736e81d4aeb6d8e1a6dc46","thumb":"https://unsplash.imgix.net/photo-1426287658398-5a912ce1ed0a?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=1fbfb0c63d75ad7d5ae454ea693b52b5"},"links":{"self":"http://api.lvh.me:3000/photos/pChE-f_gqVc","html":"http://lvh.me:3000/photos/pChE-f_gqVc","download":"http://lvh.me:3000/photos/pChE-f_gqVc/download"}},{"id":"g56z-vE98B4","urls":{"regular":"https://unsplash.imgix.net/reserve/UzWklzFdRBSbkRKhEnvc_1-6128.jpg?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=436c1302f1e0e41e9e4e76a768827445","small":"https://unsplash.imgix.net/reserve/UzWklzFdRBSbkRKhEnvc_1-6128.jpg?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=71e0cbdaee17332f7c096747729ecb96","thumb":"https://unsplash.imgix.net/reserve/UzWklzFdRBSbkRKhEnvc_1-6128.jpg?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=cef2a72819feb95bf16fedac0b5a0217"},"links":{"self":"http://api.lvh.me:3000/photos/g56z-vE98B4","html":"http://lvh.me:3000/photos/g56z-vE98B4","download":"http://lvh.me:3000/photos/g56z-vE98B4/download"}}]}'
+    http_version:
+  recorded_at: Mon, 22 Jun 2015 19:34:34 GMT
+- request:
+    method: get
+    uri: http://api.lvh.me:3000/search/photos?page=1&per_page=3&query=dog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Client-ID baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - "*"
+      Link:
+      - <http://api.lvh.me:3000/search/photos?page=6&query=dog>; rel="last",
+        <http://api.lvh.me:3000/search/photos?page=2&query=dog>; rel="next"
+      X-Total:
+      - '24'
+      X-Per-Page:
+      - '4'
+      Cache-Control:
+      - max-age=7200, public
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2644'
+      Etag:
+      - W/"b7b756f05ce3a55065dbac3a592d5bb7"
+      X-Request-Id:
+      - fd84dbae-1bb0-400c-9184-45fa0a5fdbda
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '959'
+      X-Runtime:
+      - '0.039180'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
+      Date:
+      - Mon, 22 Jun 2015 19:34:34 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"total":10,"total_pages":1,"results":[{"id":"J75SjdIvfoE","urls":{"regular":"https://ununsplash.imgix.net/photo-1424915950309-955546acf037?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=a2020e053595b065e3de1a794afe0c83","small":"https://ununsplash.imgix.net/photo-1424915950309-955546acf037?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=cba622b6ac52c5f799e9468b270df4da","thumb":"https://ununsplash.imgix.net/photo-1424915950309-955546acf037?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=3c7bb86ec4a19901d5b2d1141eaa4511"},"links":{"self":"http://api.lvh.me:3000/photos/J75SjdIvfoE","html":"http://lvh.me:3000/photos/J75SjdIvfoE","download":"http://lvh.me:3000/photos/J75SjdIvfoE/download"}},{"id":"Fu8pblIzEL0","urls":{"regular":"https://unsplash.imgix.net/photo-1425678013935-cafcfb4272c7?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=d9aeec038e349aeaf3179be303118ace","small":"https://unsplash.imgix.net/photo-1425678013935-cafcfb4272c7?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=c0fe3331e74a24705cdfe34444590ccd","thumb":"https://unsplash.imgix.net/photo-1425678013935-cafcfb4272c7?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=441c557a1af327596ff6f141ae653585"},"links":{"self":"http://api.lvh.me:3000/photos/Fu8pblIzEL0","html":"http://lvh.me:3000/photos/Fu8pblIzEL0","download":"http://lvh.me:3000/photos/Fu8pblIzEL0/download"}},{"id":"pChE-f_gqVc","urls":{"regular":"https://unsplash.imgix.net/photo-1426287658398-5a912ce1ed0a?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=252911cdb2fcb31be15811568e36d4f6","small":"https://unsplash.imgix.net/photo-1426287658398-5a912ce1ed0a?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=e672f02cb4736e81d4aeb6d8e1a6dc46","thumb":"https://unsplash.imgix.net/photo-1426287658398-5a912ce1ed0a?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=1fbfb0c63d75ad7d5ae454ea693b52b5"},"links":{"self":"http://api.lvh.me:3000/photos/pChE-f_gqVc","html":"http://lvh.me:3000/photos/pChE-f_gqVc","download":"http://lvh.me:3000/photos/pChE-f_gqVc/download"}}]}'
     http_version:
   recorded_at: Mon, 22 Jun 2015 19:34:34 GMT
 - request:

--- a/spec/cassettes/users.yml
+++ b/spec/cassettes/users.yml
@@ -848,7 +848,7 @@ http_interactions:
   recorded_at: Fri, 08 Apr 2016 16:17:11 GMT
 - request:
     method: get
-    uri: http://api.lvh.me:3000/search/users?page=1&query=ches
+    uri: http://api.lvh.me:3000/search/users?page=1&per_page=10&query=ches
     body:
       encoding: US-ASCII
       string: ''
@@ -900,7 +900,7 @@ http_interactions:
   recorded_at: Fri, 08 Apr 2016 16:17:11 GMT
 - request:
     method: get
-    uri: http://api.lvh.me:3000/search/users?page=1&query=veryveryspecific
+    uri: http://api.lvh.me:3000/search/users?page=1&per_page=10&query=veryveryspecific
     body:
       encoding: US-ASCII
       string: ''
@@ -948,6 +948,59 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"total":0,"total_pages":1,"results":[]}'
+    http_version:
+  recorded_at: Fri, 08 Apr 2016 16:17:11 GMT
+- request:
+    method: get
+    uri: http://api.lvh.me:3000/search/users?page=1&per_page=2&query=ches
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Client-ID baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Link,X-Total,X-Per-Page,X-RateLimit-Limit,X-RateLimit-Remaining
+      Content-Type:
+      - application/json
+      Link:
+      - <http://api.lvh.me:3000/search/users?page=1&query=ches>; rel="last",
+        <http://api.lvh.me:3000/search/users?page=1&query=ches>; rel="next"
+      Etag:
+      - W/"d751713988987e9331980363e24189ce"
+      Cache-Control:
+      - must-revalidate, private, max-age=0
+      X-Request-Id:
+      - 4b6f6477-3d01-418e-bc14-36d794d01b34
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '94'
+      X-Runtime:
+      - '0.030372'
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      - __profilin=p%3Dt; path=/
+      - __profilin=p%3Dt; path=/
+      X-Miniprofiler-Ids:
+      - '["1pquetshmkrovzl5lsoe","tklag0w5hvkn1t9wsbr7","y8jt1tiydp52t0qc4a9l","y6l70h07lvtas0q01rus","j5d80228amce8t5i1vhh","9hqcnbg26mwq9mjyu2d","ag74bnhwkzndi1tj72j6","f5dnndzvmjqp8jpsldeu","x5hecvstlduek0ta4g5g","srffo8hzjqvm4cqwf3pf"]'
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: '{"total":2,"total_pages":1,"results":[{"username":"lukechesser","first_name":"Luke","last_name":"Chesser","portfolio_url":"http://imluke.me/","links":{"self":"http://api.lvh.me:3000/users/lukechesser","html":"http://lvh.me:3000/lukechesser","photos":"http://api.lvh.me:3000/users/lukechesser/photos"}},
+      {"username":"lukechesser","first_name":"Luke","last_name":"Chesser","portfolio_url":"http://imluke.me/","links":{"self":"http://api.lvh.me:3000/users/lukechesser","html":"http://lvh.me:3000/lukechesser","photos":"http://api.lvh.me:3000/users/lukechesser/photos"}}]}'
     http_version:
   recorded_at: Fri, 08 Apr 2016 16:17:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/lib/collection_spec.rb
+++ b/spec/lib/collection_spec.rb
@@ -73,6 +73,16 @@ describe Unsplash::Collection do
 
       expect(@collections).to eq []
     end
+
+    it "returns an array of Collections with number of elements per page defined" do
+      VCR.use_cassette("collections") do
+        @collections = Unsplash::Collection.search("explore", 1, 2)
+      end
+
+      expect(@collections).to be_an Array
+      expect(@collections.sample).to be_an Unsplash::Collection
+      expect(@collections.size).to eq 2
+    end
   end
 
   describe "#all" do

--- a/spec/lib/photo_spec.rb
+++ b/spec/lib/photo_spec.rb
@@ -127,6 +127,15 @@ describe Unsplash::Photo do
       expect(@photos).to be_an Array
       expect(@photos.size).to eq 4
     end
+
+    it "returns an array of Photos with number of elements per page defined" do
+      VCR.use_cassette("photos") do
+        @photos = Unsplash::Photo.search("dog", 1, 3)
+      end
+
+      expect(@photos).to be_an Array
+      expect(@photos.size).to eq 3
+    end
   end
 
   describe "#index" do

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -43,6 +43,16 @@ describe Unsplash::User do
 
       expect(@users).to eq []
     end
+
+    it "returns an array of Users with number of elements per page defined" do
+      VCR.use_cassette("users") do
+        @users = Unsplash::User.search("ches", 1, 2)
+      end
+
+      expect(@users).to be_an Array
+      expect(@users.sample).to be_an Unsplash::User
+      expect(@users.size).to eq 2
+    end
   end
 
   describe "#likes" do
@@ -111,9 +121,7 @@ describe Unsplash::User do
       end
     end
 
-
   end
-
 
   describe "non-public scope actions" do
 


### PR DESCRIPTION
Hi guys, thanks for the awesome job with the Unsplash platform. This PR allows User, Collection and Photo search method receive number of elements `per_page` param. As follow:

```
collections = Unsplash::Collection.search('explore', 1, 25)
users = Unsplash::User.search('ches', 1, 30)
photos = Unsplash::Photo.search('dog', 1, 3)
```

Since that the params `api_base_uri` and`oauth_base_uri` of `Unsplash::Connection` on spec helper points to some server running local, based on #26 PR solution, I've added three new requests for VCR cassettes used on these specs.

Let me know if there is something to improve, thanks!