### PR TITLE
Allow Photo.all method to be order by

### DIFF
--- a/lib/unsplash/connection.rb
+++ b/lib/unsplash/connection.rb
@@ -123,5 +123,4 @@ module Unsplash #:nodoc:
     end
   end
 
-
 end

--- a/lib/unsplash/photo.rb
+++ b/lib/unsplash/photo.rb
@@ -90,11 +90,13 @@ module Unsplash # :nodoc:
       # Get a list of all photos.
       # @param page  [Integer] Which page of search results to return.
       # @param per_page [Integer] The number of search results per page. (default: 10, maximum: 30)
+      # @param order_by [String] How to sort the photos.
       # @return [Array] A single page of +Unsplash::Photo+ search results.
-      def all(page = 1, per_page = 10)
+      def all(page = 1, per_page = 10, order_by = "latest")
         params = {
           page:     page,
-          per_page: per_page
+          per_page: per_page,
+          order_by: order_by
         }
         parse_list connection.get("/photos/", params).body
       end

--- a/lib/unsplash/search.rb
+++ b/lib/unsplash/search.rb
@@ -2,6 +2,7 @@ module Unsplash # :nodoc:
 
   # Unsplash Search operations
   class Search < Client
+
     class << self
       # Helper class to facilitate search on multiple classes
       # @param url [String] Url to be searched into

--- a/lib/unsplash/user.rb
+++ b/lib/unsplash/user.rb
@@ -1,4 +1,4 @@
-module Unsplash # nodoc:
+module Unsplash # :nodoc:
 
   # Unsplash User operations.
   class User < Client

--- a/spec/cassettes/photos.yml
+++ b/spec/cassettes/photos.yml
@@ -91,7 +91,59 @@ http_interactions:
   recorded_at: Mon, 22 Jun 2015 19:32:54 GMT
 - request:
     method: get
-    uri: http://api.lvh.me:3000/photos/?page=1&per_page=6
+    uri: http://api.lvh.me:3000/photos/?order_by=latest&page=1&per_page=6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Client-ID baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - "*"
+      Link:
+      - <http://api.lvh.me:3000/photos?page=576&per_page=6>; rel="last", <http://api.lvh.me:3000/photos?page=2&per_page=6>;
+        rel="next"
+      X-Total:
+      - '3454'
+      X-Per-Page:
+      - '6'
+      Cache-Control:
+      - max-age=7200, public
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3943'
+      Etag:
+      - W/"26001960f0fca68e062b30fc44544084"
+      X-Request-Id:
+      - aaddd248-83f1-45d1-8cbc-5295420c11fb
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '960'
+      X-Runtime:
+      - '0.067624'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13)
+      Date:
+      - Mon, 22 Jun 2015 19:34:34 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"esm80lpf2kE","urls":{"regular":"https://ununsplash.imgix.net/photo-1433116209692-9330d85f1afb?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=639d0f9069b778709d219781497f2268","small":"https://ununsplash.imgix.net/photo-1433116209692-9330d85f1afb?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=5619ece8766efd2bbaa3eb18521138ce","thumb":"https://ununsplash.imgix.net/photo-1433116209692-9330d85f1afb?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=a3ff5ea821f38e86daab7f9569d657b5"},"links":{"self":"http://api.lvh.me:3000/photos/esm80lpf2kE","html":"http://lvh.me:3000/photos/esm80lpf2kE","download":"http://lvh.me:3000/photos/esm80lpf2kE/download"}},{"id":"bUsIoLKTk18","urls":{"regular":"https://unsplash.imgix.net/photo-1433100325891-378af68b3b8e?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=6d8a4dfeb744406f080c535afc01c65b","small":"https://unsplash.imgix.net/photo-1433100325891-378af68b3b8e?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=a89c66d2342239b76dd5de2776cdde86","thumb":"https://unsplash.imgix.net/photo-1433100325891-378af68b3b8e?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=b8d118a9ab354492259988d5e6811f94"},"links":{"self":"http://api.lvh.me:3000/photos/bUsIoLKTk18","html":"http://lvh.me:3000/photos/bUsIoLKTk18","download":"http://lvh.me:3000/photos/bUsIoLKTk18/download"}},{"id":"OVRxj5h6n7o","urls":{"regular":"https://ununsplash.imgix.net/photo-1433094657682-205abd5f883b?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=7ab44e3617f1b122758155343b35a29b","small":"https://ununsplash.imgix.net/photo-1433094657682-205abd5f883b?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=d38ee958dad8a8390c015ab1765004a0","thumb":"https://ununsplash.imgix.net/photo-1433094657682-205abd5f883b?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=b4a97c22b3463303394c8f77d6f760d4"},"links":{"self":"http://api.lvh.me:3000/photos/OVRxj5h6n7o","html":"http://lvh.me:3000/photos/OVRxj5h6n7o","download":"http://lvh.me:3000/photos/OVRxj5h6n7o/download"}},{"id":"KGRZFB1U25I","urls":{"regular":"https://ununsplash.imgix.net/photo-1433093833773-10e0c78a401b?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=38e144963a4a1dfc6c68692550bf9b04","small":"https://ununsplash.imgix.net/photo-1433093833773-10e0c78a401b?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=476ab6101647ac45786915537b199327","thumb":"https://ununsplash.imgix.net/photo-1433093833773-10e0c78a401b?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=315b37cf4dee17879d9016f6b026c826"},"links":{"self":"http://api.lvh.me:3000/photos/KGRZFB1U25I","html":"http://lvh.me:3000/photos/KGRZFB1U25I","download":"http://lvh.me:3000/photos/KGRZFB1U25I/download"}},{"id":"8CCQ-55MTUw","urls":{"regular":"https://unsplash.imgix.net/photo-1433087870301-b85d84efc18a?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=72ba2c921b8d50bda6fd64a4a8310ef8","small":"https://unsplash.imgix.net/photo-1433087870301-b85d84efc18a?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=55a324883b24065a21c4cdc0c8877d90","thumb":"https://unsplash.imgix.net/photo-1433087870301-b85d84efc18a?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=a79f21313ff22e1532ee0f4203a9603c"},"links":{"self":"http://api.lvh.me:3000/photos/8CCQ-55MTUw","html":"http://lvh.me:3000/photos/8CCQ-55MTUw","download":"http://lvh.me:3000/photos/8CCQ-55MTUw/download"}},{"id":"0Ebrm0d-G_E","urls":{"regular":"https://unsplash.imgix.net/photo-1433087639215-37846ea63501?q=75\u0026fm=jpg\u0026w=1080\u0026fit=max\u0026s=4452fdb5f2afef59a7678c27bb6a86d5","small":"https://unsplash.imgix.net/photo-1433087639215-37846ea63501?q=75\u0026fm=jpg\u0026w=400\u0026fit=max\u0026s=9bd804a341ae0b704d453288543f0c0f","thumb":"https://unsplash.imgix.net/photo-1433087639215-37846ea63501?q=75\u0026fm=jpg\u0026w=200\u0026fit=max\u0026s=95450ed3f84177040e7395b8d324cbe6"},"links":{"self":"http://api.lvh.me:3000/photos/0Ebrm0d-G_E","html":"http://lvh.me:3000/photos/0Ebrm0d-G_E","download":"http://lvh.me:3000/photos/0Ebrm0d-G_E/download"}}]'
+    http_version:
+  recorded_at: Mon, 22 Jun 2015 19:34:34 GMT
+- request:
+    method: get
+    uri: http://api.lvh.me:3000/photos/?order_by=oldest&page=1&per_page=6
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/lib/photo_spec.rb
+++ b/spec/lib/photo_spec.rb
@@ -147,6 +147,15 @@ describe Unsplash::Photo do
       expect(@photos).to be_an Array
       expect(@photos.size).to eq 6
     end
+
+    it "returns an array of Photos order by oldest criteria" do
+      VCR.use_cassette("photos") do
+        @photos = Unsplash::Photo.all(1, 6, "oldest")
+      end
+
+      expect(@photos).to be_an Array
+      expect(@photos.size).to eq 6
+    end
   end
 
   describe "#curated" do


### PR DESCRIPTION
Hy guys, this PR allows Photo all method to be sorted by `order_by` param. As follows:

```
Unsplash::Photo.all(1, 30, 'popular')
```

Let me know if there is something to improve, thanks