### PR TITLE
Send utm params

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Unsplash.configure do |config|
   config.application_id     = "YOUR APPLICATION ID"    
   config.application_secret = "YOUR APPLICATION SECRET"
   config.application_redirect_uri = "https://your-application.com/oauth/callback"
+  config.utm_source = "alices_terrific_client_app"
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Unsplash.configure do |config|
 end
 ```
 
+#### UTM parameters
+
+As part of [the API guidelines](https://community.unsplash.com/developersblog/unsplash-api-guidelines), all API uses are required to use utm links when providing credit to photographers and Unsplash. Set the `config.utm_source` to your app's name to automatically append the utm source.
+
 ### Public-scope actions
 
 If you are *only* making public requests (i.e. nothing requiring a specific logged-in user, for example liking photos or accessing private user details), then you're ready to go!

--- a/lib/unsplash/configuration.rb
+++ b/lib/unsplash/configuration.rb
@@ -4,6 +4,7 @@ module Unsplash # :nodoc:
     attr_accessor :application_secret
     attr_accessor :application_redirect_uri
     attr_accessor :logger
+    attr_accessor :utm_source
     attr_writer   :test
 
     def initialize

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -4,7 +4,7 @@ describe Unsplash::Connection do
 
   let(:connection) { Unsplash::Client.connection }
 
-  describe "utm_source params" do
+  describe "utm params", utm: true do
     before :each do
       response = double("response", status: 200, headers: {})
       allow(Unsplash::Connection).to receive(:get).and_return(response)
@@ -12,11 +12,12 @@ describe Unsplash::Connection do
     end
 
     after :each do
-      Unsplash.configuration.utm_source = nil
+      Unsplash.configuration.utm_source = "unsplash_rb_specs"
       Unsplash.configuration.logger = Logger.new(STDOUT)
     end
 
     it "warns if you don't have a utm_source" do
+      Unsplash.configuration.utm_source = nil
       connection.get("/example.json")
       expect(Unsplash.configuration.logger).to have_received(:warn)
     end

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -4,6 +4,44 @@ describe Unsplash::Connection do
 
   let(:connection) { Unsplash::Client.connection }
 
+  describe "utm_source params" do
+    before :each do
+      response = double("response", status: 200, headers: {})
+      allow(Unsplash::Connection).to receive(:get).and_return(response)
+      Unsplash.configuration.logger = double("logger", warn: nil)
+    end
+
+    after :each do
+      Unsplash.configuration.utm_source = nil
+      Unsplash.configuration.logger = Logger.new(STDOUT)
+    end
+
+    it "warns if you don't have a utm_source" do
+      connection.get("/example.json")
+      expect(Unsplash.configuration.logger).to have_received(:warn)
+    end
+
+    it "does not warn if you do have a utm_source" do
+      Unsplash.configuration.utm_source = "my_app"
+      connection.get("/example.json")
+      expect(Unsplash.configuration.logger).to_not have_received(:warn)
+    end
+
+    it "appends the utm params" do
+      headers = { "Authorization"=> "Client-ID #{Unsplash.configuration.application_id}" }
+      params = {
+        foo: "bar",
+        utm_source:   "my_app",
+        utm_medium:   "referral",
+        utm_campaign: "api-credit"
+      }
+
+      Unsplash.configuration.utm_source = "my_app"
+      connection.get("/example.json", { foo: "bar" })
+      expect(Unsplash::Connection).to have_received(:get).with("/example.json", query: params, headers: headers)
+    end
+  end
+
   describe "#extract_token" do
     context "with an established connection" do
       it "returns @oauth_token converted to a hash" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ Coveralls.wear!
 Unsplash.configure do |config|
   config.application_id = "baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3"
   config.application_secret = "bb834160d12304045c55d0c0ec2eb0fe62a5fe249bc1a392386120d55eb2793a"
+  config.utm_source = "unsplash_rb_specs"
 end
 
 VCR.configure do |config|
@@ -26,12 +27,15 @@ RSpec.configure do |config|
 
   config.order = "random"
 
-  config.before :each do
+  config.before :each do |example|
     Unsplash::Client.connection = Unsplash::Connection.new(
                                   api_base_uri:   "http://api.lvh.me:3000",
                                   oauth_base_uri: "http://www.lvh.me:3000")
-  end
 
+    if !example.metadata[:utm]
+      allow_any_instance_of(Unsplash::Connection).to receive(:utm_params).and_return({})
+    end
+  end
 end
 
 


### PR DESCRIPTION
#### Overview

- Closes #42

API terms now require sending `utm_*` params to the API.