### PR TITLE
Change default VCR matchers to :path and :query

### DIFF
--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -139,7 +139,7 @@ describe Unsplash::User do
 
       it "fails without a Bearer token" do
         expect {
-          VCR.use_cassette("users", match_requests_on: [:auth_header, :uri]) do
+          VCR.use_cassette("users", match_requests_on: [:auth_header, :path, :query]) do
             @user = Unsplash::User.current
           end
         }.to raise_error Unsplash::Error
@@ -150,7 +150,7 @@ describe Unsplash::User do
       it "returns the updated current user" do
         stub_oauth_authorization
 
-        VCR.use_cassette("users", match_requests_on: [:auth_header, :uri]) do
+        VCR.use_cassette("users", match_requests_on: [:auth_header, :path, :query]) do
           @user = Unsplash::User.update_current last_name: "Jangly"
         end
 
@@ -160,7 +160,7 @@ describe Unsplash::User do
 
       it "fails without a Bearer token" do
         expect {
-          VCR.use_cassette("users", match_requests_on: [:headers, :uri]) do
+          VCR.use_cassette("users", match_requests_on: [:headers, :path, :query]) do
             @user = Unsplash::User.update_current last_name: "Jangly"
           end
         }.to raise_error Unsplash::Error
@@ -168,5 +168,5 @@ describe Unsplash::User do
     end
 
   end
-  
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ Unsplash.configure do |config|
 end
 
 VCR.configure do |config|
+  config.default_cassette_options = { match_requests_on: [:method, :path, :query] }
   config.cassette_library_dir = "spec/cassettes"
   config.hook_into :webmock
   config.register_request_matcher :auth_header do |request_1, request_2|


### PR DESCRIPTION
Default matchers are `[:method, :uri]`. This PR changes it `:uri` to `[:path, :query]`. I tested this locally by changing the host of a few entries and the RSpec config with no failures or issues.

I did not adjust the default settings to `api.unsplash.com`. A contributor would have to change their key anyways to get this working. Let me know if you want me to change this.

Closes #38