### PR TITLE
Adds SearchResult decorator

### DIFF
--- a/lib/unsplash.rb
+++ b/lib/unsplash.rb
@@ -1,5 +1,6 @@
 require "oauth2"
 require "httparty"
+require "delegate"
 
 require "unsplash/version"
 require "unsplash/configuration"

--- a/lib/unsplash/collection.rb
+++ b/lib/unsplash/collection.rb
@@ -1,4 +1,4 @@
-module Unsplash # :nodoc: 
+module Unsplash # :nodoc:
 
   # Unsplash Collection operations.
   class Collection < Client
@@ -30,7 +30,7 @@ module Unsplash # :nodoc:
       # Get a list of all featured collections.
       # @param page [Integer] Which page of results to return.
       # @param per_page [Integer] The number of results per page. (default: 10, maximum: 30)
-      # @return [Array] A single page of the +Unsplash::Collection+ list.      
+      # @return [Array] A single page of the +Unsplash::Collection+ list.
       def featured(page = 1, per_page = 10)
         params = {
           page:     page,
@@ -58,7 +58,7 @@ module Unsplash # :nodoc:
       # @param description [String] The collection's description. (optional)
       # @param private [Boolean] Whether to make the collection private. (optional, default +false+)
       def create(title: "", description: "", private: false)
-        params = { 
+        params = {
           title:       title,
           description: description,
           private:     private
@@ -70,7 +70,7 @@ module Unsplash # :nodoc:
       # @param query [String] Keywords to search for.
       # @param page  [Integer] Which page of search results to return.
       # @param per_page [Integer] The number of collections search result per page. (default: 10, maximum: 30)
-      # @return [Array] a list of +Unsplash::Collection+ objects. 
+      # @return [SearchResult] a list of +Unsplash::Collection+ objects.
       def search(query, page = 1, per_page = 10)
         params = {
           query:    query,
@@ -93,7 +93,7 @@ module Unsplash # :nodoc:
     # @param description [String] The collection's description. (optional)
     # @param private [Boolean] Whether to make the collection private. (optional)
     def update(title: nil, description: nil, private: nil)
-      params = { 
+      params = {
         title:       title,
         description: description,
         private:     private

--- a/lib/unsplash/photo.rb
+++ b/lib/unsplash/photo.rb
@@ -77,7 +77,7 @@ module Unsplash # :nodoc:
       # @param query [String] Keywords to search for.
       # @param page  [Integer] Which page of search results to return.
       # @param per_page [Integer] The number of users search result per page. (default: 10, maximum: 30)
-      # @return [Array] a list of +Unsplash::Photo+ objects.
+      # @return [SearchResult] a list of +Unsplash::Photo+ objects.
       def search(query, page = 1, per_page = 10)
         params = {
           query:    query,

--- a/lib/unsplash/search.rb
+++ b/lib/unsplash/search.rb
@@ -1,5 +1,21 @@
 module Unsplash # :nodoc:
 
+  # Decorates Array of klass-type objects with total and total_pages attributes
+  class SearchResult < SimpleDelegator
+    attr_reader :total, :total_pages
+
+    def initialize(decorated, klass)
+      @total = decorated["total"]
+      @total_pages = decorated["total_pages"]
+
+      list = decorated["results"].map do |content|
+        klass.new content.to_hash
+      end
+
+      super(list)
+    end
+  end
+
   # Unsplash Search operations
   class Search < Client
 
@@ -8,12 +24,10 @@ module Unsplash # :nodoc:
       # @param url [String] Url to be searched into
       # @param klass [Class] Class to instantiate the contents with
       # @param params [Hash] Params for the search
+      # @return [SearchResult] Decorated Array of klass-type objects
       def search(url, klass, params)
         list = JSON.parse(connection.get(url, params).body)
-
-        list["results"].map do |content|
-          klass.new content.to_hash
-        end
+        SearchResult.new(list, klass)
       end
     end
   end

--- a/spec/lib/collection_spec.rb
+++ b/spec/lib/collection_spec.rb
@@ -56,32 +56,38 @@ describe Unsplash::Collection do
   end
 
   describe "#search" do
-    it "returns an array of Collections" do
+    it "returns a SearchResult of Collections" do
       VCR.use_cassette("collections") do
         @collections = Unsplash::Collection.search("explore", 1)
       end
 
-      expect(@collections).to be_an Array
+      expect(@collections).to be_an Unsplash::SearchResult
       expect(@collections.sample).to be_an Unsplash::Collection
       expect(@collections.size).to eq 1
+      expect(@collections.total).to eq 1
+      expect(@collections.total_pages).to eq 1
     end
 
-    it "returns an empty array if there are no users found" do
+    it "returns an empty SearchResult if there are no users found" do
       VCR.use_cassette("collections") do
         @collections = Unsplash::Collection.search("veryveryspecific", 1)
       end
 
       expect(@collections).to eq []
+      expect(@collections.total).to eq 1
+      expect(@collections.total_pages).to eq 1
     end
 
-    it "returns an array of Collections with number of elements per page defined" do
+    it "returns a SearchResult of Collections with number of elements per page defined" do
       VCR.use_cassette("collections") do
         @collections = Unsplash::Collection.search("explore", 1, 2)
       end
 
-      expect(@collections).to be_an Array
+      expect(@collections).to be_an Unsplash::SearchResult
       expect(@collections.sample).to be_an Unsplash::Collection
       expect(@collections.size).to eq 2
+      expect(@collections.total).to eq 2
+      expect(@collections.total_pages).to eq 1
     end
   end
 
@@ -94,7 +100,7 @@ describe Unsplash::Collection do
       expect(@collections).to be_an Array
       expect(@collections.size).to eq 12
     end
-    
+
     it "parses the nested user objects" do
       VCR.use_cassette("collections") do
         @collections = Unsplash::Collection.all(1, 12)
@@ -159,7 +165,7 @@ describe Unsplash::Collection do
       VCR.use_cassette("collections") do
         @collection = @collection.update(title: "Penultimate Faves")
       end
-      
+
       expect(@collection).to be_a Unsplash::Collection
     end
 
@@ -168,7 +174,7 @@ describe Unsplash::Collection do
         @collection = Unsplash::Collection.find(@collection.id)
         @collection.update(title: "Best Picturez")
       end
-      
+
       expect(@collection.title).to eq "Best Picturez"
     end
 
@@ -205,7 +211,7 @@ describe Unsplash::Collection do
 
     it "returns a metadata hash" do
       stub_oauth_authorization
-      
+
       VCR.use_cassette("collections") do
         collection = Unsplash::Collection.find(301)
         meta = collection.add(@photo)

--- a/spec/lib/photo_spec.rb
+++ b/spec/lib/photo_spec.rb
@@ -119,22 +119,26 @@ describe Unsplash::Photo do
   end
 
   describe "#search" do
-    it "returns an array of Photos" do
+    it "returns a SearchResult of Photos" do
       VCR.use_cassette("photos") do
         @photos = Unsplash::Photo.search("dog", 1)
       end
 
-      expect(@photos).to be_an Array
+      expect(@photos).to be_an Unsplash::SearchResult
       expect(@photos.size).to eq 4
+      expect(@photos.total).to eq 10
+      expect(@photos.total_pages).to eq 1
     end
 
-    it "returns an array of Photos with number of elements per page defined" do
+    it "returns a SearchResult of Photos with number of elements per page defined" do
       VCR.use_cassette("photos") do
         @photos = Unsplash::Photo.search("dog", 1, 3)
       end
 
-      expect(@photos).to be_an Array
+      expect(@photos).to be_an Unsplash::SearchResult
       expect(@photos.size).to eq 3
+      expect(@photos.total).to eq 10
+      expect(@photos.total_pages).to eq 1
     end
   end
 

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -26,32 +26,38 @@ describe Unsplash::User do
   end
 
   describe "#search" do
-    it "returns an array of Users" do
+    it "returns a SearchResult of Users" do
       VCR.use_cassette("users") do
         @users = Unsplash::User.search("ches", 1)
       end
 
-      expect(@users).to be_an Array
+      expect(@users).to be_an Unsplash::SearchResult
       expect(@users.sample).to be_an Unsplash::User
       expect(@users.size).to eq 1
+      expect(@users.total).to eq 1
+      expect(@users.total_pages).to eq 1
     end
 
-    it "returns an empty array if there are no users found" do
+    it "returns an empty SearchResult if there are no users found" do
       VCR.use_cassette("users") do
         @users = Unsplash::User.search("veryveryspecific", 1)
       end
 
       expect(@users).to eq []
+      expect(@users.total).to eq 0
+      expect(@users.total_pages).to eq 1
     end
 
-    it "returns an array of Users with number of elements per page defined" do
+    it "returns a SearchResult of Users with number of elements per page defined" do
       VCR.use_cassette("users") do
         @users = Unsplash::User.search("ches", 1, 2)
       end
 
-      expect(@users).to be_an Array
+      expect(@users).to be_an Unsplash::SearchResult
       expect(@users.sample).to be_an Unsplash::User
       expect(@users.size).to eq 2
+      expect(@users.total).to eq 2
+      expect(@users.total_pages).to eq 1
     end
   end
 
@@ -168,5 +174,5 @@ describe Unsplash::User do
     end
 
   end
-  
+
 end


### PR DESCRIPTION
SearchResult decorates klass-type objects to include the `total` and
`total_pages` attributes that the API returns.
https://unsplash.com/documentation#search-photos

Closes #40