### PR TITLE
Allow Photo#search to recieve orientation parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea/

--- a/lib/unsplash/photo.rb
+++ b/lib/unsplash/photo.rb
@@ -54,7 +54,7 @@ module Unsplash # :nodoc:
       # @param orientation [String] Filter by orientation of the photo. Valid values are landscape, portrait, and squarish.
       # @return [Unsplash::Photo] An Unsplash Photo if count parameter is omitted
       # @return [Array] An array of Unsplash Photos if the count parameter is specified. An array is returned even if count is 1
-      def random(count: nil,categories: nil, collections: nil, featured: nil, user: nil, query: nil, width: nil, height: nil, orientation: nil)
+      def random(count: nil, categories: nil, collections: nil, featured: nil, user: nil, query: nil, width: nil, height: nil, orientation: nil)
         params = {
           category: (categories && categories.join(",")),
           collections: (collections && collections.join(",")),
@@ -83,12 +83,14 @@ module Unsplash # :nodoc:
       # @param query [String] Keywords to search for.
       # @param page  [Integer] Which page of search results to return.
       # @param per_page [Integer] The number of users search result per page. (default: 10, maximum: 30)
+      # @param orientation [String] Filter by orientation of the photo. Valid values are landscape, portrait, and squarish.
       # @return [SearchResult] a list of +Unsplash::Photo+ objects.
-      def search(query, page = 1, per_page = 10)
+      def search(query, page = 1, per_page = 10, orientation = nil)
         params = {
           query:    query,
           page:     page,
-          per_page: per_page
+          per_page: per_page,
+          orientation: orientation
         }
         Unsplash::Search.search("/search/photos", self, params)
       end

--- a/spec/cassettes/photos.yml
+++ b/spec/cassettes/photos.yml
@@ -829,4 +829,356 @@ http_interactions:
       string: '{"url":"https://images.unsplash.com/1/macbook-air-all-faded-and-stuff.jpg?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&s=f33f08b334c34ffe513f1a0fdf72bb71"}'
     http_version: 
   recorded_at: Fri, 08 Dec 2017 20:42:04 GMT
+- request:
+    method: get
+    uri: https://api.unsplash.com/search/photos?orientation=&page=1&per_page=10&query=dog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Client-ID baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Link,X-Total,X-Per-Page,X-RateLimit-Limit,X-RateLimit-Remaining
+      Link:
+      - <https://api.unsplash.com/search/photos?orientation=&page=100&per_page=10&query=dog>;
+        rel="last", <https://api.unsplash.com/search/photos?orientation=&page=2&per_page=10&query=dog>;
+        rel="next"
+      X-Total:
+      - '1001'
+      X-Per-Page:
+      - '10'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Type:
+      - application/json
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '99'
+      X-Request-Id:
+      - 0dbc206a-1647-46da-924a-08ecb955ffcc
+      X-Runtime:
+      - '0.101363'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      - 1.1 vegur
+      Fastly-Debug-Digest:
+      - 91e500706266f9ead52e6b083af1dcc018aa28249a6ac9d5b63f9899111c541c
+      Content-Length:
+      - '29279'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 04 Mar 2018 18:11:03 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2132-IAD, cache-ams4434-AMS
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1520187063.231331,VS0,VE189
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"total":1001,"total_pages":101,"results":[{"id":"pChE-f_gqVc","created_at":"2015-03-13T19:01:04-04:00","updated_at":"2017-11-01T15:36:32-04:00","width":3008,"height":2000,"color":"#3F4140","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=056f1d604de9158136b51aec793074fd","full":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=ae9ff4eb8f78a76009c59b57e648050a","regular":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=034f1422aca25d22903af855ab9db778","small":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=c774fa8326a42964b055e1c4d7c2a2bc","thumb":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=f74357b345c7b18cf62bbd18f947b16e"},"links":{"self":"https://api.unsplash.com/photos/pChE-f_gqVc","html":"https://unsplash.com/photos/pChE-f_gqVc","download":"https://unsplash.com/photos/pChE-f_gqVc/download","download_location":"https://api.unsplash.com/photos/pChE-f_gqVc/download"},"liked_by_user":false,"sponsored":false,"likes":168,"user":{"id":"lnGVOX2U20E","updated_at":"2018-02-23T04:17:20-05:00","username":"wlangenberg","name":"Will
+        Langenberg","first_name":"Will","last_name":"Langenberg","twitter_username":null,"portfolio_url":"http://www.willlangenberg.com","bio":null,"location":"NYC","links":{"self":"https://api.unsplash.com/users/wlangenberg","html":"https://unsplash.com/@wlangenberg","photos":"https://api.unsplash.com/users/wlangenberg/photos","likes":"https://api.unsplash.com/users/wlangenberg/likes","portfolio":"https://api.unsplash.com/users/wlangenberg/portfolio","following":"https://api.unsplash.com/users/wlangenberg/following","followers":"https://api.unsplash.com/users/wlangenberg/followers"},"profile_image":{"small":"https://images.unsplash.com/placeholder-avatars/extra-large.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=0ad68f44c4725d5a3fda019bab9d3edc","medium":"https://images.unsplash.com/placeholder-avatars/extra-large.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=356bd4b76a3d4eb97d63f45b818dd358","large":"https://images.unsplash.com/placeholder-avatars/extra-large.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=ee8bbf5fb8d6e43aaaa238feae2fe90d"},"total_collections":0,"instagram_username":"will.langenberg","total_likes":0,"total_photos":36},"current_user_collections":[],"photo_tags":[{"title":"dog"},{"title":"nature"},{"title":"listening"}]},{"id":"wT2RNG9_Jhw","created_at":"2015-10-30T15:05:28-04:00","updated_at":"2017-10-29T00:58:08-04:00","width":5184,"height":3456,"color":"#A18067","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=7f721289a217602f820078be2f29bae8","full":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=b4d90d4762503acaf7e70265cc9deabd","regular":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=ba09f5ddc22aa6627a13deba5fbc4b65","small":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=db59890797413755f73caba956bbba43","thumb":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=fd6df809868ec75ae9bcbc7da30b9894"},"links":{"self":"https://api.unsplash.com/photos/wT2RNG9_Jhw","html":"https://unsplash.com/photos/wT2RNG9_Jhw","download":"https://unsplash.com/photos/wT2RNG9_Jhw/download","download_location":"https://api.unsplash.com/photos/wT2RNG9_Jhw/download"},"liked_by_user":false,"sponsored":false,"likes":141,"user":{"id":"Yk2mOuFrp8Q","updated_at":"2018-02-22T14:50:27-05:00","username":"lbrto","name":"Gabrielle
+        Costa","first_name":"Gabrielle","last_name":"Costa","twitter_username":null,"portfolio_url":null,"bio":null,"location":null,"links":{"self":"https://api.unsplash.com/users/lbrto","html":"https://unsplash.com/@lbrto","photos":"https://api.unsplash.com/users/lbrto/photos","likes":"https://api.unsplash.com/users/lbrto/likes","portfolio":"https://api.unsplash.com/users/lbrto/portfolio","following":"https://api.unsplash.com/users/lbrto/following","followers":"https://api.unsplash.com/users/lbrto/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1446232248113-03b086cf0c70?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=0ecaf8d2282683def2ebe552c8ad3bec","medium":"https://images.unsplash.com/profile-1446232248113-03b086cf0c70?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=de3eb08c4f33e982a61b25d63f3a5d3e","large":"https://images.unsplash.com/profile-1446232248113-03b086cf0c70?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=64dd6dae726b2b4f5da7f119e401ab64"},"total_collections":0,"instagram_username":null,"total_likes":0,"total_photos":7},"current_user_collections":[],"photo_tags":[{"title":"dog"},{"title":"animal"},{"title":"canine"},{"title":"chow"},{"title":"pet"}]},{"id":"Crj3gU0aJsU","created_at":"2017-10-04T15:35:11-04:00","updated_at":"2017-10-29T21:09:25-04:00","width":4215,"height":3165,"color":"#FEFEFE","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1507145569372-d69bae8bc9a0?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=9ce16098f430674ef0399d9f0c4d9b45","full":"https://images.unsplash.com/photo-1507145569372-d69bae8bc9a0?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=52a559b5a5cb9f660542d23a727d678a","regular":"https://images.unsplash.com/photo-1507145569372-d69bae8bc9a0?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=329938eb5efce0e694ab17c7cb03c5dc","small":"https://images.unsplash.com/photo-1507145569372-d69bae8bc9a0?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=884b02e1a89ac38ee157b8c8727f52e4","thumb":"https://images.unsplash.com/photo-1507145569372-d69bae8bc9a0?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=9d13d46c17f2065893f2a0e613df50e6"},"links":{"self":"https://api.unsplash.com/photos/Crj3gU0aJsU","html":"https://unsplash.com/photos/Crj3gU0aJsU","download":"https://unsplash.com/photos/Crj3gU0aJsU/download","download_location":"https://api.unsplash.com/photos/Crj3gU0aJsU/download"},"liked_by_user":false,"sponsored":false,"likes":49,"user":{"id":"yWQ9VpYPOHE","updated_at":"2018-02-02T12:29:09-05:00","username":"berkaygumustekin","name":"Berkay
+        Gumustekin","first_name":"Berkay","last_name":"Gumustekin","twitter_username":null,"portfolio_url":null,"bio":null,"location":null,"links":{"self":"https://api.unsplash.com/users/berkaygumustekin","html":"https://unsplash.com/@berkaygumustekin","photos":"https://api.unsplash.com/users/berkaygumustekin/photos","likes":"https://api.unsplash.com/users/berkaygumustekin/likes","portfolio":"https://api.unsplash.com/users/berkaygumustekin/portfolio","following":"https://api.unsplash.com/users/berkaygumustekin/following","followers":"https://api.unsplash.com/users/berkaygumustekin/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1507145301102-a12df6093630?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=bd2a1ad8712a4fbe9f09dfde741a8b96","medium":"https://images.unsplash.com/profile-1507145301102-a12df6093630?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=23637c13fd7078939b8bfbed5c1a9055","large":"https://images.unsplash.com/profile-1507145301102-a12df6093630?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=1ea8c68a9e40789ed5cc88efc1ded452"},"total_collections":3,"instagram_username":"sberg.photo","total_likes":0,"total_photos":21},"current_user_collections":[],"photo_tags":[{"title":"pet"},{"title":"garden"},{"title":"grass"},{"title":"fence"},{"title":"path"}]},{"id":"KGy1GFeKBu4","created_at":"2015-01-12T16:35:34-05:00","updated_at":"2017-10-31T17:15:48-04:00","width":4928,"height":2772,"color":"#312F2F","description":"A
+        husky dog wearing a harness in Necropolis","categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1421098518790-5a14be02b243?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=0e403a9143805512b7fd5731b4648460","full":"https://images.unsplash.com/photo-1421098518790-5a14be02b243?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=3db2ac1d78915978f423bbb8c0890c8b","regular":"https://images.unsplash.com/photo-1421098518790-5a14be02b243?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=38b6d819ba41c8a8085cd1e70b448593","small":"https://images.unsplash.com/photo-1421098518790-5a14be02b243?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=05297286ae620578378f59958e738d4e","thumb":"https://images.unsplash.com/photo-1421098518790-5a14be02b243?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=6c8002e8aace3994fe74f224686fc919"},"links":{"self":"https://api.unsplash.com/photos/KGy1GFeKBu4","html":"https://unsplash.com/photos/KGy1GFeKBu4","download":"https://unsplash.com/photos/KGy1GFeKBu4/download","download_location":"https://api.unsplash.com/photos/KGy1GFeKBu4/download"},"liked_by_user":false,"sponsored":false,"likes":391,"user":{"id":"ek1nBTU9JME","updated_at":"2018-02-22T14:47:33-05:00","username":"xavortm","name":"Alexander
+        Dimitrov","first_name":"Alexander","last_name":"Dimitrov","twitter_username":"xavortm","portfolio_url":"http://www.xavortm.com","bio":"Designer
+        and front-end developer. Photography is a hobby that I can''t practice enough
+        :(","location":"Bulgaria, Elin Pelin","links":{"self":"https://api.unsplash.com/users/xavortm","html":"https://unsplash.com/@xavortm","photos":"https://api.unsplash.com/users/xavortm/photos","likes":"https://api.unsplash.com/users/xavortm/likes","portfolio":"https://api.unsplash.com/users/xavortm/portfolio","following":"https://api.unsplash.com/users/xavortm/following","followers":"https://api.unsplash.com/users/xavortm/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1449133222569-3cd56fda165f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=36195753290bf1d7c18c06d608f855b7","medium":"https://images.unsplash.com/profile-1449133222569-3cd56fda165f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=7cf0b1bca1c1291f92d0e4cb17955503","large":"https://images.unsplash.com/profile-1449133222569-3cd56fda165f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=b5f36ff7b48d37aad5375174c6e1c30c"},"total_collections":3,"instagram_username":"xavortm","total_likes":4,"total_photos":4},"current_user_collections":[],"photo_tags":[{"title":"animal"},{"title":"husky"},{"title":"canine"},{"title":"harness"},{"title":"royal"}]},{"id":"ZRZSmK362Xw","created_at":"2017-06-20T17:27:26-04:00","updated_at":"2017-11-01T14:16:49-04:00","width":5616,"height":5616,"color":"#0D1124","description":"A
+        vigilant black dog against a white background","categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1497993950456-cdb57afd1cf1?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=e66284d94457e4f917c0d3d34acbedef","full":"https://images.unsplash.com/photo-1497993950456-cdb57afd1cf1?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=bc78b026ac8ad458e6a4eccfcfed4d55","regular":"https://images.unsplash.com/photo-1497993950456-cdb57afd1cf1?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=76f1b889744f50aa1037691dcf49917b","small":"https://images.unsplash.com/photo-1497993950456-cdb57afd1cf1?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=767dce594d8c7c2ae70ffbb3d228a228","thumb":"https://images.unsplash.com/photo-1497993950456-cdb57afd1cf1?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=2b7f693ef70c98a8cd7ace55f1d157c4"},"links":{"self":"https://api.unsplash.com/photos/ZRZSmK362Xw","html":"https://unsplash.com/photos/ZRZSmK362Xw","download":"https://unsplash.com/photos/ZRZSmK362Xw/download","download_location":"https://api.unsplash.com/photos/ZRZSmK362Xw/download"},"liked_by_user":false,"sponsored":false,"likes":308,"user":{"id":"BnNu7uZ8y1I","updated_at":"2017-12-16T07:59:28-05:00","username":"kennykiyoshi","name":"Ken
+        Reid","first_name":"Ken","last_name":"Reid","twitter_username":null,"portfolio_url":null,"bio":null,"location":"Hot
+        Springs, AR","links":{"self":"https://api.unsplash.com/users/kennykiyoshi","html":"https://unsplash.com/@kennykiyoshi","photos":"https://api.unsplash.com/users/kennykiyoshi/photos","likes":"https://api.unsplash.com/users/kennykiyoshi/likes","portfolio":"https://api.unsplash.com/users/kennykiyoshi/portfolio","following":"https://api.unsplash.com/users/kennykiyoshi/following","followers":"https://api.unsplash.com/users/kennykiyoshi/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1481240460658-069b6b3ed769?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=128bfa428e4f0c84641c95c31e47ac29","medium":"https://images.unsplash.com/profile-1481240460658-069b6b3ed769?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=87ee65d701e18fc3eedac345a78b1685","large":"https://images.unsplash.com/profile-1481240460658-069b6b3ed769?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=6bcd7db0d153419d0c96ad437e839e01"},"total_collections":0,"instagram_username":"kennykiyoshi","total_likes":2,"total_photos":6},"current_user_collections":[],"photo_tags":[{"title":"pet"},{"title":"dog"},{"title":"puppy"},{"title":"minimal"},{"title":"retriever"}]},{"id":"CdK2eYhWfQ0","created_at":"2017-09-05T03:11:06-04:00","updated_at":"2017-11-01T15:14:22-04:00","width":4000,"height":6000,"color":"#D4DDE4","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1504595403659-9088ce801e29?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=53044d47d5fa718e534e6d3940b7458c","full":"https://images.unsplash.com/photo-1504595403659-9088ce801e29?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=591b099c1e8310b7802733671014407a","regular":"https://images.unsplash.com/photo-1504595403659-9088ce801e29?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=1e36034ef5462574ccd12dcae95334b6","small":"https://images.unsplash.com/photo-1504595403659-9088ce801e29?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=ec719491ddde7802b88b1adcd6c8c740","thumb":"https://images.unsplash.com/photo-1504595403659-9088ce801e29?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=88747cbe1e11184ba56ed0a9553a356a"},"links":{"self":"https://api.unsplash.com/photos/CdK2eYhWfQ0","html":"https://unsplash.com/photos/CdK2eYhWfQ0","download":"https://unsplash.com/photos/CdK2eYhWfQ0/download","download_location":"https://api.unsplash.com/photos/CdK2eYhWfQ0/download"},"liked_by_user":false,"sponsored":false,"likes":178,"user":{"id":"WVNqD4RBVXc","updated_at":"2018-02-22T14:45:45-05:00","username":"jaywennington","name":"Jay
+        Wennington","first_name":"Jay","last_name":"Wennington","twitter_username":"jaywennington","portfolio_url":"https://www.instagram.com/jaywennington/","bio":"Photographer,
+        designer & content creative. Working with bands & brands across the world.
+        Regular globetrotter, currently based in Melbourne, Australia.","location":"Melbourne","links":{"self":"https://api.unsplash.com/users/jaywennington","html":"https://unsplash.com/@jaywennington","photos":"https://api.unsplash.com/users/jaywennington/photos","likes":"https://api.unsplash.com/users/jaywennington/likes","portfolio":"https://api.unsplash.com/users/jaywennington/portfolio","following":"https://api.unsplash.com/users/jaywennington/following","followers":"https://api.unsplash.com/users/jaywennington/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1496904177663-8656de65bf50?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=6f97b902fa949cb58d8a2f89eab3e363","medium":"https://images.unsplash.com/profile-1496904177663-8656de65bf50?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=11d768e19faa89e4ca7f7304a8f738e9","large":"https://images.unsplash.com/profile-1496904177663-8656de65bf50?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=5b99708dd4633b3cb345c232c14728ad"},"total_collections":1,"instagram_username":"jaywennington","total_likes":18,"total_photos":68},"current_user_collections":[],"photo_tags":[{"title":"dog"},{"title":"pet"},{"title":"loyal"},{"title":"animal"},{"title":"labrador"}]},{"id":"JCXANpeR2XI","created_at":"2015-07-26T20:33:13-04:00","updated_at":"2017-10-31T17:15:50-04:00","width":4752,"height":4752,"color":"#B5AAA5","description":"A
+        little dog sleeping in Katowice","categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1437957146754-f6377debe171?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=9d10aff090da7ae4aa2d427f2d074bf7","full":"https://images.unsplash.com/photo-1437957146754-f6377debe171?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=b29bc39848fbe2e87a39c42da333fae5","regular":"https://images.unsplash.com/photo-1437957146754-f6377debe171?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=92ef0812bb20f054e11b2a9a2f68fdf8","small":"https://images.unsplash.com/photo-1437957146754-f6377debe171?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=8883760bee32eb8165f0e4fa0bab626e","thumb":"https://images.unsplash.com/photo-1437957146754-f6377debe171?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=43d031e97bb7eb087fb73198c3f1704e"},"links":{"self":"https://api.unsplash.com/photos/JCXANpeR2XI","html":"https://unsplash.com/photos/JCXANpeR2XI","download":"https://unsplash.com/photos/JCXANpeR2XI/download","download_location":"https://api.unsplash.com/photos/JCXANpeR2XI/download"},"liked_by_user":false,"sponsored":false,"likes":296,"user":{"id":"e4Ic8JPbgb8","updated_at":"2018-02-22T14:50:17-05:00","username":"agmakonts","name":"Adam
+        Grabek","first_name":"Adam","last_name":"Grabek","twitter_username":"agmakonts","portfolio_url":"http://code-mine.com","bio":null,"location":"Katowice,
+        Poland","links":{"self":"https://api.unsplash.com/users/agmakonts","html":"https://unsplash.com/@agmakonts","photos":"https://api.unsplash.com/users/agmakonts/photos","likes":"https://api.unsplash.com/users/agmakonts/likes","portfolio":"https://api.unsplash.com/users/agmakonts/portfolio","following":"https://api.unsplash.com/users/agmakonts/following","followers":"https://api.unsplash.com/users/agmakonts/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1451904390814-b25a1d93d21d?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=6006aad63ab65ed4ac1ce9cb01159751","medium":"https://images.unsplash.com/profile-1451904390814-b25a1d93d21d?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=dc5b2b97dbf1dd40d5d4766bea9c8a68","large":"https://images.unsplash.com/profile-1451904390814-b25a1d93d21d?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=cc8bec621d165bfae3519b6e591b99df"},"total_collections":0,"instagram_username":"agmakonts","total_likes":28,"total_photos":34},"current_user_collections":[],"photo_tags":[{"title":"dog"},{"title":"sleep"},{"title":"toy
+        dog"},{"title":"shih-tzu"},{"title":"canine"}]},{"id":"NKN25UfGfkQ","created_at":"2017-04-07T18:45:13-04:00","updated_at":"2017-10-31T17:19:51-04:00","width":4000,"height":6000,"color":"#F4F4F4","description":"Close-up
+        of the head of a husky dog","categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1491604612772-6853927639ef?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=a40bb68bec3c9f8c4ad667da316e3392","full":"https://images.unsplash.com/photo-1491604612772-6853927639ef?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=4baefd8fa587c112d5300903e528a6ab","regular":"https://images.unsplash.com/photo-1491604612772-6853927639ef?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=325b9d89e85024bc5cb68f95f7ef54a9","small":"https://images.unsplash.com/photo-1491604612772-6853927639ef?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=1726a099cc9e6c881c2d89222c071ff7","thumb":"https://images.unsplash.com/photo-1491604612772-6853927639ef?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=60d22e013a2cf463824d16a963cd03c6"},"links":{"self":"https://api.unsplash.com/photos/NKN25UfGfkQ","html":"https://unsplash.com/photos/NKN25UfGfkQ","download":"https://unsplash.com/photos/NKN25UfGfkQ/download","download_location":"https://api.unsplash.com/photos/NKN25UfGfkQ/download"},"liked_by_user":false,"sponsored":false,"likes":229,"user":{"id":"dJoCQ6e4h64","updated_at":"2018-02-22T16:01:05-05:00","username":"kierancwhite","name":"Kieran
+        White","first_name":"Kieran","last_name":"White","twitter_username":"KieranCWhite","portfolio_url":null,"bio":"Aspiring
+        photographer from Dorset in England.\r\n\r\nInstagram: @kierancwhite","location":"Dorset,
+        England","links":{"self":"https://api.unsplash.com/users/kierancwhite","html":"https://unsplash.com/@kierancwhite","photos":"https://api.unsplash.com/users/kierancwhite/photos","likes":"https://api.unsplash.com/users/kierancwhite/likes","portfolio":"https://api.unsplash.com/users/kierancwhite/portfolio","following":"https://api.unsplash.com/users/kierancwhite/following","followers":"https://api.unsplash.com/users/kierancwhite/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1484587108580-ad5deb64059d?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=5522547e1bd7628c5524af74eed2cb9a","medium":"https://images.unsplash.com/profile-1484587108580-ad5deb64059d?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=a04ddcb1c1fc22d900a5af890e6daf10","large":"https://images.unsplash.com/profile-1484587108580-ad5deb64059d?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=eb9a5f8825a9cb3286407e4eb2f979ef"},"total_collections":0,"instagram_username":"kierancwhite","total_likes":506,"total_photos":32},"current_user_collections":[],"photo_tags":[{"title":"husky"},{"title":"dog"},{"title":"pet"},{"title":"animal"},{"title":"canine"}]},{"id":"O8Q6vqHPyko","created_at":"2017-10-30T15:50:40-04:00","updated_at":"2017-11-01T13:46:16-04:00","width":4480,"height":6720,"color":"#FFFBE6","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1509393011839-182e9b61f10f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=e723615599fc1f0b877cfb9eb85a3af5","full":"https://images.unsplash.com/photo-1509393011839-182e9b61f10f?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=ee8d2160745600228f3b17bb8e740213","regular":"https://images.unsplash.com/photo-1509393011839-182e9b61f10f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=145744e7f20893b282845c68ab553809","small":"https://images.unsplash.com/photo-1509393011839-182e9b61f10f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=7241d4c1fbfbd4ea07abf70800cfacd9","thumb":"https://images.unsplash.com/photo-1509393011839-182e9b61f10f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=9c598ac45a017ff3efd121bc98e616a1"},"links":{"self":"https://api.unsplash.com/photos/O8Q6vqHPyko","html":"https://unsplash.com/photos/O8Q6vqHPyko","download":"https://unsplash.com/photos/O8Q6vqHPyko/download","download_location":"https://api.unsplash.com/photos/O8Q6vqHPyko/download"},"liked_by_user":false,"sponsored":false,"likes":56,"user":{"id":"worKDSXm1Yw","updated_at":"2018-03-04T11:10:01-05:00","username":"rpnickson","name":"Roberto
+        Nickson (@g)","first_name":"Roberto","last_name":"Nickson (@g)","twitter_username":"rpnickson","portfolio_url":null,"bio":"Instagram:
+        @g","location":null,"links":{"self":"https://api.unsplash.com/users/rpnickson","html":"https://unsplash.com/@rpnickson","photos":"https://api.unsplash.com/users/rpnickson/photos","likes":"https://api.unsplash.com/users/rpnickson/likes","portfolio":"https://api.unsplash.com/users/rpnickson/portfolio","following":"https://api.unsplash.com/users/rpnickson/following","followers":"https://api.unsplash.com/users/rpnickson/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-fb-1448518158-e754ed1466c9.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=c963a917a81a628f2695ad7ee326265c","medium":"https://images.unsplash.com/profile-fb-1448518158-e754ed1466c9.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=795d1d83a2cfce4a446ecc9645f629f6","large":"https://images.unsplash.com/profile-fb-1448518158-e754ed1466c9.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=433f4858993451431d0765ac829440ab"},"total_collections":0,"instagram_username":"g","total_likes":2,"total_photos":84},"current_user_collections":[],"photo_tags":[{"title":"pet"},{"title":"fur"},{"title":"face"},{"title":"portrait"},{"title":"tongue"}]},{"id":"duoz1NfjoRA","created_at":"2017-05-24T05:06:14-04:00","updated_at":"2017-10-31T12:13:15-04:00","width":4016,"height":6016,"color":"#D4F3EE","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1495616667594-eb40788d6897?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=28c9b7566456c41c6d3c69c97b3b8248","full":"https://images.unsplash.com/photo-1495616667594-eb40788d6897?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=d0b3a3b4f91129ceae9f49c744d85518","regular":"https://images.unsplash.com/photo-1495616667594-eb40788d6897?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=02d1d5a8e44b64825ced97f4712af8c6","small":"https://images.unsplash.com/photo-1495616667594-eb40788d6897?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=2ac359bec296aea161916e9d0dd7f844","thumb":"https://images.unsplash.com/photo-1495616667594-eb40788d6897?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=ab0e71d5742e1cdabab84a7e2280acb8"},"links":{"self":"https://api.unsplash.com/photos/duoz1NfjoRA","html":"https://unsplash.com/photos/duoz1NfjoRA","download":"https://unsplash.com/photos/duoz1NfjoRA/download","download_location":"https://api.unsplash.com/photos/duoz1NfjoRA/download"},"liked_by_user":false,"sponsored":false,"likes":248,"user":{"id":"pcIalpHAIp8","updated_at":"2018-03-01T09:30:39-05:00","username":"buzzyrobot","name":"Dawid
+        Sobolewski","first_name":"Dawid","last_name":"Sobolewski","twitter_username":"dawidsobolewski","portfolio_url":"https://www.instagram.com/buzzyrobot/","bio":"UI/UX
+        Designer and amateur photographer.","location":"Warsaw","links":{"self":"https://api.unsplash.com/users/buzzyrobot","html":"https://unsplash.com/@buzzyrobot","photos":"https://api.unsplash.com/users/buzzyrobot/photos","likes":"https://api.unsplash.com/users/buzzyrobot/likes","portfolio":"https://api.unsplash.com/users/buzzyrobot/portfolio","following":"https://api.unsplash.com/users/buzzyrobot/following","followers":"https://api.unsplash.com/users/buzzyrobot/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-fb-1445370701-f739a144b6d6.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=97eaa033e07298eab3a1b933a25e5772","medium":"https://images.unsplash.com/profile-fb-1445370701-f739a144b6d6.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=e90e899b3cb5473b19cc1ac855489b0c","large":"https://images.unsplash.com/profile-fb-1445370701-f739a144b6d6.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=8c150e12d214a489e8b5fa90cedc346e"},"total_collections":0,"instagram_username":"buzzyrobot","total_likes":11,"total_photos":36},"current_user_collections":[],"photo_tags":[{"title":"woman"},{"title":"lady"},{"title":"female"},{"title":"golen
+        hour"},{"title":"dog"}]}]}'
+    http_version: 
+  recorded_at: Sun, 04 Mar 2018 18:11:03 GMT
+- request:
+    method: get
+    uri: https://api.unsplash.com/search/photos?orientation=landscape&page=1&per_page=3&query=dog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Client-ID baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Link,X-Total,X-Per-Page,X-RateLimit-Limit,X-RateLimit-Remaining
+      Link:
+      - <https://api.unsplash.com/search/photos?orientation=landscape&page=254&per_page=3&query=dog>;
+        rel="last", <https://api.unsplash.com/search/photos?orientation=landscape&page=2&per_page=3&query=dog>;
+        rel="next"
+      X-Total:
+      - '764'
+      X-Per-Page:
+      - '3'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Type:
+      - application/json
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '98'
+      X-Request-Id:
+      - 88eb6b8c-2f97-4efc-81f7-606afab7cb23
+      X-Runtime:
+      - '0.056492'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      - 1.1 vegur
+      Fastly-Debug-Digest:
+      - 7529178740a47ac8faa697919b978d4c0b75713d281aa5a50027fa09c405c60e
+      Content-Length:
+      - '8689'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 04 Mar 2018 18:11:03 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2124-IAD, cache-ams4440-AMS
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1520187064.563691,VS0,VE144
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"total":764,"total_pages":255,"results":[{"id":"pChE-f_gqVc","created_at":"2015-03-13T19:01:04-04:00","updated_at":"2017-11-01T15:36:32-04:00","width":3008,"height":2000,"color":"#3F4140","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=056f1d604de9158136b51aec793074fd","full":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=ae9ff4eb8f78a76009c59b57e648050a","regular":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=034f1422aca25d22903af855ab9db778","small":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=c774fa8326a42964b055e1c4d7c2a2bc","thumb":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=f74357b345c7b18cf62bbd18f947b16e"},"links":{"self":"https://api.unsplash.com/photos/pChE-f_gqVc","html":"https://unsplash.com/photos/pChE-f_gqVc","download":"https://unsplash.com/photos/pChE-f_gqVc/download","download_location":"https://api.unsplash.com/photos/pChE-f_gqVc/download"},"liked_by_user":false,"sponsored":false,"likes":168,"user":{"id":"lnGVOX2U20E","updated_at":"2018-02-23T04:17:20-05:00","username":"wlangenberg","name":"Will
+        Langenberg","first_name":"Will","last_name":"Langenberg","twitter_username":null,"portfolio_url":"http://www.willlangenberg.com","bio":null,"location":"NYC","links":{"self":"https://api.unsplash.com/users/wlangenberg","html":"https://unsplash.com/@wlangenberg","photos":"https://api.unsplash.com/users/wlangenberg/photos","likes":"https://api.unsplash.com/users/wlangenberg/likes","portfolio":"https://api.unsplash.com/users/wlangenberg/portfolio","following":"https://api.unsplash.com/users/wlangenberg/following","followers":"https://api.unsplash.com/users/wlangenberg/followers"},"profile_image":{"small":"https://images.unsplash.com/placeholder-avatars/extra-large.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=0ad68f44c4725d5a3fda019bab9d3edc","medium":"https://images.unsplash.com/placeholder-avatars/extra-large.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=356bd4b76a3d4eb97d63f45b818dd358","large":"https://images.unsplash.com/placeholder-avatars/extra-large.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=ee8bbf5fb8d6e43aaaa238feae2fe90d"},"total_collections":0,"instagram_username":"will.langenberg","total_likes":0,"total_photos":36},"current_user_collections":[],"photo_tags":[{"title":"dog"},{"title":"nature"},{"title":"listening"}]},{"id":"wT2RNG9_Jhw","created_at":"2015-10-30T15:05:28-04:00","updated_at":"2017-10-29T00:58:08-04:00","width":5184,"height":3456,"color":"#A18067","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=7f721289a217602f820078be2f29bae8","full":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=b4d90d4762503acaf7e70265cc9deabd","regular":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=ba09f5ddc22aa6627a13deba5fbc4b65","small":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=db59890797413755f73caba956bbba43","thumb":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=fd6df809868ec75ae9bcbc7da30b9894"},"links":{"self":"https://api.unsplash.com/photos/wT2RNG9_Jhw","html":"https://unsplash.com/photos/wT2RNG9_Jhw","download":"https://unsplash.com/photos/wT2RNG9_Jhw/download","download_location":"https://api.unsplash.com/photos/wT2RNG9_Jhw/download"},"liked_by_user":false,"sponsored":false,"likes":141,"user":{"id":"Yk2mOuFrp8Q","updated_at":"2018-02-22T14:50:27-05:00","username":"lbrto","name":"Gabrielle
+        Costa","first_name":"Gabrielle","last_name":"Costa","twitter_username":null,"portfolio_url":null,"bio":null,"location":null,"links":{"self":"https://api.unsplash.com/users/lbrto","html":"https://unsplash.com/@lbrto","photos":"https://api.unsplash.com/users/lbrto/photos","likes":"https://api.unsplash.com/users/lbrto/likes","portfolio":"https://api.unsplash.com/users/lbrto/portfolio","following":"https://api.unsplash.com/users/lbrto/following","followers":"https://api.unsplash.com/users/lbrto/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1446232248113-03b086cf0c70?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=0ecaf8d2282683def2ebe552c8ad3bec","medium":"https://images.unsplash.com/profile-1446232248113-03b086cf0c70?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=de3eb08c4f33e982a61b25d63f3a5d3e","large":"https://images.unsplash.com/profile-1446232248113-03b086cf0c70?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=64dd6dae726b2b4f5da7f119e401ab64"},"total_collections":0,"instagram_username":null,"total_likes":0,"total_photos":7},"current_user_collections":[],"photo_tags":[{"title":"dog"},{"title":"animal"},{"title":"canine"},{"title":"chow"},{"title":"pet"}]},{"id":"KGy1GFeKBu4","created_at":"2015-01-12T16:35:34-05:00","updated_at":"2017-10-31T17:15:48-04:00","width":4928,"height":2772,"color":"#312F2F","description":"A
+        husky dog wearing a harness in Necropolis","categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1421098518790-5a14be02b243?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=0e403a9143805512b7fd5731b4648460","full":"https://images.unsplash.com/photo-1421098518790-5a14be02b243?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=3db2ac1d78915978f423bbb8c0890c8b","regular":"https://images.unsplash.com/photo-1421098518790-5a14be02b243?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=38b6d819ba41c8a8085cd1e70b448593","small":"https://images.unsplash.com/photo-1421098518790-5a14be02b243?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=05297286ae620578378f59958e738d4e","thumb":"https://images.unsplash.com/photo-1421098518790-5a14be02b243?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=6c8002e8aace3994fe74f224686fc919"},"links":{"self":"https://api.unsplash.com/photos/KGy1GFeKBu4","html":"https://unsplash.com/photos/KGy1GFeKBu4","download":"https://unsplash.com/photos/KGy1GFeKBu4/download","download_location":"https://api.unsplash.com/photos/KGy1GFeKBu4/download"},"liked_by_user":false,"sponsored":false,"likes":391,"user":{"id":"ek1nBTU9JME","updated_at":"2018-02-22T14:47:33-05:00","username":"xavortm","name":"Alexander
+        Dimitrov","first_name":"Alexander","last_name":"Dimitrov","twitter_username":"xavortm","portfolio_url":"http://www.xavortm.com","bio":"Designer
+        and front-end developer. Photography is a hobby that I can''t practice enough
+        :(","location":"Bulgaria, Elin Pelin","links":{"self":"https://api.unsplash.com/users/xavortm","html":"https://unsplash.com/@xavortm","photos":"https://api.unsplash.com/users/xavortm/photos","likes":"https://api.unsplash.com/users/xavortm/likes","portfolio":"https://api.unsplash.com/users/xavortm/portfolio","following":"https://api.unsplash.com/users/xavortm/following","followers":"https://api.unsplash.com/users/xavortm/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1449133222569-3cd56fda165f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=36195753290bf1d7c18c06d608f855b7","medium":"https://images.unsplash.com/profile-1449133222569-3cd56fda165f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=7cf0b1bca1c1291f92d0e4cb17955503","large":"https://images.unsplash.com/profile-1449133222569-3cd56fda165f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=b5f36ff7b48d37aad5375174c6e1c30c"},"total_collections":3,"instagram_username":"xavortm","total_likes":4,"total_photos":4},"current_user_collections":[],"photo_tags":[{"title":"animal"},{"title":"husky"},{"title":"canine"},{"title":"harness"},{"title":"royal"}]}]}'
+    http_version: 
+  recorded_at: Sun, 04 Mar 2018 18:11:03 GMT
+- request:
+    method: get
+    uri: https://api.unsplash.com/search/photos?orientation=&page=1&per_page=3&query=dog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Client-ID baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Link,X-Total,X-Per-Page,X-RateLimit-Limit,X-RateLimit-Remaining
+      Link:
+      - <https://api.unsplash.com/search/photos?orientation=&page=333&per_page=3&query=dog>;
+        rel="last", <https://api.unsplash.com/search/photos?orientation=&page=2&per_page=3&query=dog>;
+        rel="next"
+      X-Total:
+      - '1001'
+      X-Per-Page:
+      - '3'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Type:
+      - application/json
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '97'
+      X-Request-Id:
+      - bc57df24-55ea-459e-bc34-87ec677b59f7
+      X-Runtime:
+      - '0.078247'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      - 1.1 vegur
+      Fastly-Debug-Digest:
+      - 004561e0d412899a73837160c99890f3017cba6729cfe6a859809a1baeb150a6
+      Content-Length:
+      - '8588'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 04 Mar 2018 18:11:03 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2129-IAD, cache-ams4145-AMS
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1520187064.818100,VS0,VE173
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"total":1001,"total_pages":334,"results":[{"id":"pChE-f_gqVc","created_at":"2015-03-13T19:01:04-04:00","updated_at":"2017-11-01T15:36:32-04:00","width":3008,"height":2000,"color":"#3F4140","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=056f1d604de9158136b51aec793074fd","full":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=ae9ff4eb8f78a76009c59b57e648050a","regular":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=034f1422aca25d22903af855ab9db778","small":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=c774fa8326a42964b055e1c4d7c2a2bc","thumb":"https://images.unsplash.com/photo-1426287658398-5a912ce1ed0a?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=f74357b345c7b18cf62bbd18f947b16e"},"links":{"self":"https://api.unsplash.com/photos/pChE-f_gqVc","html":"https://unsplash.com/photos/pChE-f_gqVc","download":"https://unsplash.com/photos/pChE-f_gqVc/download","download_location":"https://api.unsplash.com/photos/pChE-f_gqVc/download"},"liked_by_user":false,"sponsored":false,"likes":168,"user":{"id":"lnGVOX2U20E","updated_at":"2018-02-23T04:17:20-05:00","username":"wlangenberg","name":"Will
+        Langenberg","first_name":"Will","last_name":"Langenberg","twitter_username":null,"portfolio_url":"http://www.willlangenberg.com","bio":null,"location":"NYC","links":{"self":"https://api.unsplash.com/users/wlangenberg","html":"https://unsplash.com/@wlangenberg","photos":"https://api.unsplash.com/users/wlangenberg/photos","likes":"https://api.unsplash.com/users/wlangenberg/likes","portfolio":"https://api.unsplash.com/users/wlangenberg/portfolio","following":"https://api.unsplash.com/users/wlangenberg/following","followers":"https://api.unsplash.com/users/wlangenberg/followers"},"profile_image":{"small":"https://images.unsplash.com/placeholder-avatars/extra-large.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=0ad68f44c4725d5a3fda019bab9d3edc","medium":"https://images.unsplash.com/placeholder-avatars/extra-large.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=356bd4b76a3d4eb97d63f45b818dd358","large":"https://images.unsplash.com/placeholder-avatars/extra-large.jpg?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=ee8bbf5fb8d6e43aaaa238feae2fe90d"},"total_collections":0,"instagram_username":"will.langenberg","total_likes":0,"total_photos":36},"current_user_collections":[],"photo_tags":[{"title":"dog"},{"title":"nature"},{"title":"listening"}]},{"id":"wT2RNG9_Jhw","created_at":"2015-10-30T15:05:28-04:00","updated_at":"2017-10-29T00:58:08-04:00","width":5184,"height":3456,"color":"#A18067","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=7f721289a217602f820078be2f29bae8","full":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=b4d90d4762503acaf7e70265cc9deabd","regular":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=ba09f5ddc22aa6627a13deba5fbc4b65","small":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=db59890797413755f73caba956bbba43","thumb":"https://images.unsplash.com/photo-1446231855385-1d4b0f025248?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=fd6df809868ec75ae9bcbc7da30b9894"},"links":{"self":"https://api.unsplash.com/photos/wT2RNG9_Jhw","html":"https://unsplash.com/photos/wT2RNG9_Jhw","download":"https://unsplash.com/photos/wT2RNG9_Jhw/download","download_location":"https://api.unsplash.com/photos/wT2RNG9_Jhw/download"},"liked_by_user":false,"sponsored":false,"likes":141,"user":{"id":"Yk2mOuFrp8Q","updated_at":"2018-02-22T14:50:27-05:00","username":"lbrto","name":"Gabrielle
+        Costa","first_name":"Gabrielle","last_name":"Costa","twitter_username":null,"portfolio_url":null,"bio":null,"location":null,"links":{"self":"https://api.unsplash.com/users/lbrto","html":"https://unsplash.com/@lbrto","photos":"https://api.unsplash.com/users/lbrto/photos","likes":"https://api.unsplash.com/users/lbrto/likes","portfolio":"https://api.unsplash.com/users/lbrto/portfolio","following":"https://api.unsplash.com/users/lbrto/following","followers":"https://api.unsplash.com/users/lbrto/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1446232248113-03b086cf0c70?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=0ecaf8d2282683def2ebe552c8ad3bec","medium":"https://images.unsplash.com/profile-1446232248113-03b086cf0c70?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=de3eb08c4f33e982a61b25d63f3a5d3e","large":"https://images.unsplash.com/profile-1446232248113-03b086cf0c70?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=64dd6dae726b2b4f5da7f119e401ab64"},"total_collections":0,"instagram_username":null,"total_likes":0,"total_photos":7},"current_user_collections":[],"photo_tags":[{"title":"dog"},{"title":"animal"},{"title":"canine"},{"title":"chow"},{"title":"pet"}]},{"id":"Crj3gU0aJsU","created_at":"2017-10-04T15:35:11-04:00","updated_at":"2017-10-29T21:09:25-04:00","width":4215,"height":3165,"color":"#FEFEFE","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1507145569372-d69bae8bc9a0?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=9ce16098f430674ef0399d9f0c4d9b45","full":"https://images.unsplash.com/photo-1507145569372-d69bae8bc9a0?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=52a559b5a5cb9f660542d23a727d678a","regular":"https://images.unsplash.com/photo-1507145569372-d69bae8bc9a0?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=329938eb5efce0e694ab17c7cb03c5dc","small":"https://images.unsplash.com/photo-1507145569372-d69bae8bc9a0?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=884b02e1a89ac38ee157b8c8727f52e4","thumb":"https://images.unsplash.com/photo-1507145569372-d69bae8bc9a0?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=9d13d46c17f2065893f2a0e613df50e6"},"links":{"self":"https://api.unsplash.com/photos/Crj3gU0aJsU","html":"https://unsplash.com/photos/Crj3gU0aJsU","download":"https://unsplash.com/photos/Crj3gU0aJsU/download","download_location":"https://api.unsplash.com/photos/Crj3gU0aJsU/download"},"liked_by_user":false,"sponsored":false,"likes":49,"user":{"id":"yWQ9VpYPOHE","updated_at":"2018-02-02T12:29:09-05:00","username":"berkaygumustekin","name":"Berkay
+        Gumustekin","first_name":"Berkay","last_name":"Gumustekin","twitter_username":null,"portfolio_url":null,"bio":null,"location":null,"links":{"self":"https://api.unsplash.com/users/berkaygumustekin","html":"https://unsplash.com/@berkaygumustekin","photos":"https://api.unsplash.com/users/berkaygumustekin/photos","likes":"https://api.unsplash.com/users/berkaygumustekin/likes","portfolio":"https://api.unsplash.com/users/berkaygumustekin/portfolio","following":"https://api.unsplash.com/users/berkaygumustekin/following","followers":"https://api.unsplash.com/users/berkaygumustekin/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1507145301102-a12df6093630?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=bd2a1ad8712a4fbe9f09dfde741a8b96","medium":"https://images.unsplash.com/profile-1507145301102-a12df6093630?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=23637c13fd7078939b8bfbed5c1a9055","large":"https://images.unsplash.com/profile-1507145301102-a12df6093630?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=1ea8c68a9e40789ed5cc88efc1ded452"},"total_collections":3,"instagram_username":"sberg.photo","total_likes":0,"total_photos":21},"current_user_collections":[],"photo_tags":[{"title":"pet"},{"title":"garden"},{"title":"grass"},{"title":"fence"},{"title":"path"}]}]}'
+    http_version: 
+  recorded_at: Sun, 04 Mar 2018 18:11:04 GMT
+- request:
+    method: get
+    uri: https://api.unsplash.com/search/photos?orientation=portrait&page=1&per_page=3&query=dog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Client-ID baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Link,X-Total,X-Per-Page,X-RateLimit-Limit,X-RateLimit-Remaining
+      Link:
+      - <https://api.unsplash.com/search/photos?orientation=portrait&page=65&per_page=3&query=dog>;
+        rel="last", <https://api.unsplash.com/search/photos?orientation=portrait&page=2&per_page=3&query=dog>;
+        rel="next"
+      X-Total:
+      - '196'
+      X-Per-Page:
+      - '3'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Type:
+      - application/json
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '96'
+      X-Request-Id:
+      - c6dae148-b2f1-45c2-94dd-ac5651e89de2
+      X-Runtime:
+      - '0.115773'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      - 1.1 vegur
+      Fastly-Debug-Digest:
+      - 7f175e509d51d511251229c435bc06afbe299c62eaf6abfee31c6fdff526d8ad
+      Content-Length:
+      - '8986'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 04 Mar 2018 18:15:54 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2126-IAD, cache-ams4125-AMS
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1520187354.916798,VS0,VE211
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '{"total":196,"total_pages":66,"results":[{"id":"CdK2eYhWfQ0","created_at":"2017-09-05T03:11:06-04:00","updated_at":"2017-11-01T15:14:22-04:00","width":4000,"height":6000,"color":"#D4DDE4","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1504595403659-9088ce801e29?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=53044d47d5fa718e534e6d3940b7458c","full":"https://images.unsplash.com/photo-1504595403659-9088ce801e29?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=591b099c1e8310b7802733671014407a","regular":"https://images.unsplash.com/photo-1504595403659-9088ce801e29?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=1e36034ef5462574ccd12dcae95334b6","small":"https://images.unsplash.com/photo-1504595403659-9088ce801e29?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=ec719491ddde7802b88b1adcd6c8c740","thumb":"https://images.unsplash.com/photo-1504595403659-9088ce801e29?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=88747cbe1e11184ba56ed0a9553a356a"},"links":{"self":"https://api.unsplash.com/photos/CdK2eYhWfQ0","html":"https://unsplash.com/photos/CdK2eYhWfQ0","download":"https://unsplash.com/photos/CdK2eYhWfQ0/download","download_location":"https://api.unsplash.com/photos/CdK2eYhWfQ0/download"},"liked_by_user":false,"sponsored":false,"likes":178,"user":{"id":"WVNqD4RBVXc","updated_at":"2018-02-22T14:45:45-05:00","username":"jaywennington","name":"Jay
+        Wennington","first_name":"Jay","last_name":"Wennington","twitter_username":"jaywennington","portfolio_url":"https://www.instagram.com/jaywennington/","bio":"Photographer,
+        designer & content creative. Working with bands & brands across the world.
+        Regular globetrotter, currently based in Melbourne, Australia.","location":"Melbourne","links":{"self":"https://api.unsplash.com/users/jaywennington","html":"https://unsplash.com/@jaywennington","photos":"https://api.unsplash.com/users/jaywennington/photos","likes":"https://api.unsplash.com/users/jaywennington/likes","portfolio":"https://api.unsplash.com/users/jaywennington/portfolio","following":"https://api.unsplash.com/users/jaywennington/following","followers":"https://api.unsplash.com/users/jaywennington/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1496904177663-8656de65bf50?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=6f97b902fa949cb58d8a2f89eab3e363","medium":"https://images.unsplash.com/profile-1496904177663-8656de65bf50?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=11d768e19faa89e4ca7f7304a8f738e9","large":"https://images.unsplash.com/profile-1496904177663-8656de65bf50?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=5b99708dd4633b3cb345c232c14728ad"},"total_collections":1,"instagram_username":"jaywennington","total_likes":18,"total_photos":68},"current_user_collections":[],"photo_tags":[{"title":"dog"},{"title":"pet"},{"title":"loyal"},{"title":"animal"},{"title":"labrador"}]},{"id":"NKN25UfGfkQ","created_at":"2017-04-07T18:45:13-04:00","updated_at":"2017-10-31T17:19:51-04:00","width":4000,"height":6000,"color":"#F4F4F4","description":"Close-up
+        of the head of a husky dog","categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1491604612772-6853927639ef?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=a40bb68bec3c9f8c4ad667da316e3392","full":"https://images.unsplash.com/photo-1491604612772-6853927639ef?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=4baefd8fa587c112d5300903e528a6ab","regular":"https://images.unsplash.com/photo-1491604612772-6853927639ef?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=325b9d89e85024bc5cb68f95f7ef54a9","small":"https://images.unsplash.com/photo-1491604612772-6853927639ef?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=1726a099cc9e6c881c2d89222c071ff7","thumb":"https://images.unsplash.com/photo-1491604612772-6853927639ef?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=60d22e013a2cf463824d16a963cd03c6"},"links":{"self":"https://api.unsplash.com/photos/NKN25UfGfkQ","html":"https://unsplash.com/photos/NKN25UfGfkQ","download":"https://unsplash.com/photos/NKN25UfGfkQ/download","download_location":"https://api.unsplash.com/photos/NKN25UfGfkQ/download"},"liked_by_user":false,"sponsored":false,"likes":229,"user":{"id":"dJoCQ6e4h64","updated_at":"2018-02-22T16:01:05-05:00","username":"kierancwhite","name":"Kieran
+        White","first_name":"Kieran","last_name":"White","twitter_username":"KieranCWhite","portfolio_url":null,"bio":"Aspiring
+        photographer from Dorset in England.\r\n\r\nInstagram: @kierancwhite","location":"Dorset,
+        England","links":{"self":"https://api.unsplash.com/users/kierancwhite","html":"https://unsplash.com/@kierancwhite","photos":"https://api.unsplash.com/users/kierancwhite/photos","likes":"https://api.unsplash.com/users/kierancwhite/likes","portfolio":"https://api.unsplash.com/users/kierancwhite/portfolio","following":"https://api.unsplash.com/users/kierancwhite/following","followers":"https://api.unsplash.com/users/kierancwhite/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1484587108580-ad5deb64059d?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=5522547e1bd7628c5524af74eed2cb9a","medium":"https://images.unsplash.com/profile-1484587108580-ad5deb64059d?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=a04ddcb1c1fc22d900a5af890e6daf10","large":"https://images.unsplash.com/profile-1484587108580-ad5deb64059d?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=eb9a5f8825a9cb3286407e4eb2f979ef"},"total_collections":0,"instagram_username":"kierancwhite","total_likes":506,"total_photos":32},"current_user_collections":[],"photo_tags":[{"title":"husky"},{"title":"dog"},{"title":"pet"},{"title":"animal"},{"title":"canine"}]},{"id":"E48Dz9_54DY","created_at":"2017-10-01T20:24:27-04:00","updated_at":"2017-10-31T15:29:47-04:00","width":2034,"height":3615,"color":"#F9C19D","description":null,"categories":[],"urls":{"raw":"https://images.unsplash.com/photo-1506903536293-8419385acdce?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEwOTJ9&s=26196a90e8f58796d9f90c799181e4f0","full":"https://images.unsplash.com/photo-1506903536293-8419385acdce?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjEwOTJ9&s=2f8eaa3043b94174fa6d2e5a0074b3b6","regular":"https://images.unsplash.com/photo-1506903536293-8419385acdce?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=6d7c660607d417a7717e4a407bce0a81","small":"https://images.unsplash.com/photo-1506903536293-8419385acdce?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=a527aee5236e91b6cedc26a70ace3415","thumb":"https://images.unsplash.com/photo-1506903536293-8419385acdce?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&ixid=eyJhcHBfaWQiOjEwOTJ9&s=ec2d4977aad86e0271cac9d7aac139ef"},"links":{"self":"https://api.unsplash.com/photos/E48Dz9_54DY","html":"https://unsplash.com/photos/E48Dz9_54DY","download":"https://unsplash.com/photos/E48Dz9_54DY/download","download_location":"https://api.unsplash.com/photos/E48Dz9_54DY/download"},"liked_by_user":false,"sponsored":false,"likes":48,"user":{"id":"qkLpDm1oSRw","updated_at":"2018-02-28T22:15:07-05:00","username":"celine_sayuri","name":"Celine
+        Sayuri Tagami","first_name":"Celine","last_name":"Sayuri Tagami","twitter_username":null,"portfolio_url":null,"bio":null,"location":null,"links":{"self":"https://api.unsplash.com/users/celine_sayuri","html":"https://unsplash.com/@celine_sayuri","photos":"https://api.unsplash.com/users/celine_sayuri/photos","likes":"https://api.unsplash.com/users/celine_sayuri/likes","portfolio":"https://api.unsplash.com/users/celine_sayuri/portfolio","following":"https://api.unsplash.com/users/celine_sayuri/following","followers":"https://api.unsplash.com/users/celine_sayuri/followers"},"profile_image":{"small":"https://images.unsplash.com/profile-1517524000936-70302b108fd5?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=6c96385803ea53016c9a72e3afc66d7d","medium":"https://images.unsplash.com/profile-1517524000936-70302b108fd5?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=8e539ed3a569581e9cbc4600fb90167c","large":"https://images.unsplash.com/profile-1517524000936-70302b108fd5?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=dcee51bba00447bc93122a2ff74cd4b6"},"total_collections":0,"instagram_username":"celine.s.t
+        ","total_likes":1,"total_photos":2},"current_user_collections":[],"photo_tags":[{"title":"dog"},{"title":"pet"},{"title":"leaves"},{"title":"autumn"},{"title":"retriever"}]}]}'
+    http_version: 
+  recorded_at: Sun, 04 Mar 2018 18:15:54 GMT
 recorded_with: VCR 3.0.3

--- a/spec/lib/photo_spec.rb
+++ b/spec/lib/photo_spec.rb
@@ -119,6 +119,10 @@ describe Unsplash::Photo do
   end
 
   describe "#search" do
+    before do
+      Unsplash::Client.connection = Unsplash::Connection.new(api_base_uri: "https://api.unsplash.com/")
+    end
+
     it "returns a SearchResult of Photos" do
       VCR.use_cassette("photos") do
         @photos = Unsplash::Photo.search("dog", 1)
@@ -126,8 +130,8 @@ describe Unsplash::Photo do
 
       expect(@photos).to be_an Unsplash::SearchResult
       expect(@photos.size).to eq 10
-      expect(@photos.total).to eq 541
-      expect(@photos.total_pages).to eq 55
+      expect(@photos.total).to eq 1001
+      expect(@photos.total_pages).to eq 101
     end
 
     it "returns a SearchResult of Photos with number of elements per page defined" do
@@ -137,8 +141,17 @@ describe Unsplash::Photo do
 
       expect(@photos).to be_an Unsplash::SearchResult
       expect(@photos.size).to eq 3
-      expect(@photos.total).to eq 541
-      expect(@photos.total_pages).to eq 181
+      expect(@photos.total).to eq 1001
+      expect(@photos.total_pages).to eq 334
+    end
+
+    it "returns a SearchResult of Photos with orientation parameter" do
+      VCR.use_cassette("photos") do
+        @photos = Unsplash::Photo.search("dog", 1, 3, :portrait)
+      end
+
+      expect(@photos).to be_an Unsplash::SearchResult
+      expect(@photos.size).to eq 3
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,9 +23,7 @@ VCR.configure do |config|
   end
 end
 
-
 RSpec.configure do |config|
-
   config.order = "random"
 
   config.before :each do |example|
@@ -38,7 +36,6 @@ RSpec.configure do |config|
     end
   end
 end
-
 
 def stub_oauth_authorization
   token = "69cca388c56e64fc2ee1c9f7cfb0dcec1bf1b384957b61c9ec6764777b98554e"


### PR DESCRIPTION
#### Overview

I added support to the orientation parameter of the `/search/photos` endpoint.

Interesting points and questions here:

- The cassetes are all pointing to the `http://api.lvh.me:3000` base API as set up in the `spec_helper.rb`. I don't think that is a good idea, since not all contributors have the Unsplash app running locally (:. I tried to change the `api_base_uri` on the `spec_helper.rb` to the official public API but the tests with the oauth authorization stubbed failed. So, I just changed the root API for the `Photo#search` method spec.
- The API doesn't respond with any data that I can confirm if the photos retrieved are really portrait (as in my test case for example). I could check if the retrieved photos have the height bigger than width, but I'm, not sure if this is completely true. How the Unsplash knows if the photo is landscape or portrait?

Let me know what do you think. Thanks

Closes #50 
