### PR TITLE
Change 'Application ID' => 'Access Key'

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and secret. If you are using Rails, you can do this in an initializer.
 
 ```ruby
 Unsplash.configure do |config|    
-  config.application_id     = "YOUR APPLICATION ID"    
+  config.application_id     = "YOUR ACCESS KEY"    
   config.application_secret = "YOUR APPLICATION SECRET"
   config.application_redirect_uri = "https://your-application.com/oauth/callback"
   config.utm_source = "alices_terrific_client_app"


### PR DESCRIPTION
After adding the unsplash gem to my project, I realized that the `config.application_id` is actually the `access key` (from the unsplash developer page) not the `application id`