### PR TITLE
Change configuration application_id to application_access_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Or install it yourself as:
 ### Configuration
 
 Before making requests, you must configure the gem with your application ID
-and secret. If you are using Rails, you can do this in an initializer. 
+and secret. If you are using Rails, you can do this in an initializer.
 
 ```ruby
-Unsplash.configure do |config|    
-  config.application_id     = "YOUR ACCESS KEY"    
+Unsplash.configure do |config|
+  config.application_access_key = "YOUR ACCESS KEY"
   config.application_secret = "YOUR APPLICATION SECRET"
   config.application_redirect_uri = "https://your-application.com/oauth/callback"
   config.utm_source = "alices_terrific_client_app"
@@ -91,7 +91,7 @@ Unlike most APIs, Unsplash requires for the image URLs returned by the API to be
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. 
+To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Contributing
 

--- a/lib/unsplash/configuration.rb
+++ b/lib/unsplash/configuration.rb
@@ -1,6 +1,6 @@
 module Unsplash # :nodoc:
   class Configuration # :nodoc:
-    attr_accessor :application_id
+    attr_accessor :application_access_key
     attr_accessor :application_secret
     attr_accessor :application_redirect_uri
     attr_accessor :logger
@@ -14,6 +14,15 @@ module Unsplash # :nodoc:
 
     def test?
       !!@test
+    end
+
+    def application_id=(key)
+      logger.warn "Configuring application_id is deprecated. Use application_access_key."
+      self.application_access_key = key
+    end
+
+    def application_id
+      application_access_key
     end
 
   end

--- a/lib/unsplash/connection.rb
+++ b/lib/unsplash/connection.rb
@@ -18,13 +18,13 @@ module Unsplash #:nodoc:
     # @param api_base_uri [String] Base URI at which to make API calls.
     # @param oauth_base_uri [String] Base URI for OAuth requests.
     def initialize(version: DEFAULT_VERSION, api_base_uri: DEFAULT_API_BASE_URI, oauth_base_uri: DEFAULT_OAUTH_BASE_URI)
-      @application_id     = Unsplash.configuration.application_id
+      @application_access_key = Unsplash.configuration.application_access_key
       @application_secret = Unsplash.configuration.application_secret
       @api_version        = version
       @api_base_uri       = api_base_uri
 
       oauth_base_uri = oauth_base_uri
-      @oauth = ::OAuth2::Client.new(@application_id, @application_secret, site: oauth_base_uri) do |http|
+      @oauth = ::OAuth2::Client.new(@application_access_key, @application_secret, site: oauth_base_uri) do |http|
         http.request :multipart
         http.request :url_encoded
         http.adapter :net_http
@@ -137,7 +137,7 @@ module Unsplash #:nodoc:
     end
 
     def public_auth_header
-      { "Authorization" => "Client-ID #{@application_id}" }
+      { "Authorization" => "Client-ID #{@application_access_key}" }
     end
 
     def utm_params

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe Unsplash::Configuration do
+  describe "using deprecated application_id" do
+    before :each do
+      @old_value = Unsplash.configuration.application_access_key
+    end
+
+    after :each do
+      Unsplash.configuration.application_access_key = @old_value
+    end
+
+    it "still assigns the value" do
+      Unsplash.configure do |config|
+        config.application_id = "access key"
+      end
+
+      expect(Unsplash.configuration.application_access_key).to eq "access key"
+    end
+
+    it "logs a warning" do
+      allow(Unsplash.configuration.logger).to receive(:warn)
+
+      Unsplash.configure do |config|
+        config.application_id = "access key"
+      end
+
+      expect(Unsplash.configuration.logger).to have_received(:warn)
+    end
+  end
+end

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -29,7 +29,7 @@ describe Unsplash::Connection do
     end
 
     it "appends the utm params" do
-      headers = { "Authorization"=> "Client-ID #{Unsplash.configuration.application_id}" }
+      headers = { "Authorization"=> "Client-ID #{Unsplash.configuration.application_access_key}" }
       params = {
         foo: "bar",
         utm_source:   "my_app",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'coveralls'
 Coveralls.wear!
 
 Unsplash.configure do |config|
-  config.application_id = "baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3"
+  config.application_access_key = "baaa6a1214d50b3586bec6e06157aab859bd4d86dc0b755360f103f38974edc3"
   config.application_secret = "bb834160d12304045c55d0c0ec2eb0fe62a5fe249bc1a392386120d55eb2793a"
   config.utm_source = "unsplash_rb_specs"
 end


### PR DESCRIPTION
#### Overview

Further to #52, we recently changed some terminology on the website to use "access key" rather than "id" for API clients. We hadn't updated this lib with that yet, though, so was causing confusion re: configuration.

This changes the configuration attribute internally, but maintains backwards compatibility (logging a deprecation warning).