### PR TITLE
Handle 500 errors as Unsplash::Error

### DIFF
--- a/lib/unsplash/connection.rb
+++ b/lib/unsplash/connection.rb
@@ -127,12 +127,14 @@ module Unsplash #:nodoc:
 
       status_code = response.respond_to?(:status) ? response.status : response.code
 
-      if status_code >= 500
+      begin
+        if !(200..299).include?(status_code)
+          body = JSON.parse(response.body)
+          msg = body["error"] || body["errors"].join(" ")
+          raise Unsplash::Error.new msg
+        end
+      rescue JSON::ParserError
         raise Unsplash::Error.new response.body
-      elsif !(200..299).include?(status_code)
-        body = JSON.parse(response.body)
-        msg = body["error"] || body["errors"].join(" ")
-        raise Unsplash::Error.new msg
       end
 
       response

--- a/lib/unsplash/connection.rb
+++ b/lib/unsplash/connection.rb
@@ -127,7 +127,9 @@ module Unsplash #:nodoc:
 
       status_code = response.respond_to?(:status) ? response.status : response.code
 
-      if !(200..299).include?(status_code)
+      if status_code >= 500
+        raise Unsplash::Error.new response.body
+      elsif !(200..299).include?(status_code)
         body = JSON.parse(response.body)
         msg = body["error"] || body["errors"].join(" ")
         raise Unsplash::Error.new msg

--- a/spec/unsplash_spec.rb
+++ b/spec/unsplash_spec.rb
@@ -12,4 +12,15 @@ describe Unsplash do
     expect(Unsplash.configuration.logger).to receive(:warn).with("Watch out!")
     Unsplash::CuratedBatch.all
   end
+
+  it "handles 5** errors as Unsplash Errors" do
+    response = double(
+      body: "We are experiencing errors. Please check https://status.unsplash.com for updates.",
+      status: 503,
+      headers: { "Content-Type" => "text/plain" }
+    )
+    allow(Unsplash::Connection).to receive(:public_send).and_return(response)
+
+    expect { Unsplash::CuratedBatch.all }.to raise_error(Unsplash::Error)
+  end
 end


### PR DESCRIPTION
>= 500 errors aren't formatted as JSON which result in
`JSON::ParserError · 765: unexpected token at 'We are experiencing
errors. Please check https://status.unsplash.com for updates.'`

Instead we can parse raise these errors as Unsplash::Error and let
users gracefully handle it