### PR TITLE
More fine-grained error classes

### DIFF
--- a/lib/unsplash/connection.rb
+++ b/lib/unsplash/connection.rb
@@ -62,9 +62,8 @@ module Unsplash #:nodoc:
     # @param token_extract [Hash] OAuth token hash from #extract_token.
     # @return [OAuth2::AccessToken, nil] New access token object.
     def create_and_assign_token(token_extract)
-      if token_extract
-        @oauth_token = OAuth2::AccessToken.from_hash(@oauth, token_extract)
-      end
+      return if !token_extract
+      @oauth_token = OAuth2::AccessToken.from_hash(@oauth, token_extract)
     end
 
     # Perform a GET request.

--- a/lib/unsplash/connection.rb
+++ b/lib/unsplash/connection.rb
@@ -130,6 +130,8 @@ module Unsplash #:nodoc:
       case status_code
       when 200..299
         response
+      when 401
+        raise Unsplash::UnauthorizedError.new(error_message(response))
       when 404
         raise Unsplash::NotFoundError.new(error_message(response))
       else

--- a/lib/unsplash/errors.rb
+++ b/lib/unsplash/errors.rb
@@ -3,5 +3,7 @@ module Unsplash # :nodoc:
   class Error < StandardError; end
   # Raise for deprecation errors
   class DeprecationError < Error; end
+
+  class UnauthorizedError < Error; end
   class NotFoundError < Error; end
 end

--- a/lib/unsplash/errors.rb
+++ b/lib/unsplash/errors.rb
@@ -5,5 +5,6 @@ module Unsplash # :nodoc:
   class DeprecationError < Error; end
 
   class UnauthorizedError < Error; end
+  class ForbiddenError < Error; end
   class NotFoundError < Error; end
 end

--- a/lib/unsplash/errors.rb
+++ b/lib/unsplash/errors.rb
@@ -3,4 +3,5 @@ module Unsplash # :nodoc:
   class Error < StandardError; end
   # Raise for deprecation errors
   class DeprecationError < Error; end
+  class NotFoundError < Error; end
 end

--- a/spec/lib/collection_spec.rb
+++ b/spec/lib/collection_spec.rb
@@ -18,7 +18,7 @@ describe Unsplash::Collection do
         VCR.use_cassette("collections") do
           Unsplash::Collection.find(fake_id)
         end
-      }.to raise_error Unsplash::Error
+      }.to raise_error Unsplash::NotFoundError
     end
 
     it "parses the nested user object" do
@@ -177,7 +177,6 @@ describe Unsplash::Collection do
       end
     end
   end
-
 
   describe "#remove" do
     before :each do

--- a/spec/lib/collection_spec.rb
+++ b/spec/lib/collection_spec.rb
@@ -121,7 +121,7 @@ describe Unsplash::Collection do
         VCR.use_cassette("collections", match_requests_on: [:method, :path, :body]) do
           Unsplash::Collection.create(title: "Pretty Good Pictures I Guess", private: true)
         end
-      }.to raise_error Unsplash::Error
+      }.to raise_error Unsplash::UnauthorizedError
     end
   end
 

--- a/spec/lib/collection_spec.rb
+++ b/spec/lib/collection_spec.rb
@@ -154,7 +154,7 @@ describe Unsplash::Collection do
           collection = Unsplash::Collection.find(4397795) # exists but does not belong to user
           collection.destroy
         end
-      }.to raise_error OAuth2::Error
+      }.to raise_error Unsplash::ForbiddenError
     end
 
   end

--- a/spec/lib/photo_spec.rb
+++ b/spec/lib/photo_spec.rb
@@ -18,7 +18,7 @@ describe Unsplash::Photo do
         VCR.use_cassette("photos") do
           @photo = Unsplash::Photo.find(fake_id)
         end
-      }.to raise_error Unsplash::Error
+      }.to raise_error Unsplash::NotFoundError
     end
 
     it "parses the nested user object" do
@@ -50,7 +50,7 @@ describe Unsplash::Photo do
         VCR.use_cassette("photos") do
           Unsplash::Photo.random(user: "bigfoot_aint_real_either")
         end
-      }.to raise_error Unsplash::Error
+      }.to raise_error Unsplash::NotFoundError
     end
 
     it "parses the nested user object" do

--- a/spec/lib/photo_spec.rb
+++ b/spec/lib/photo_spec.rb
@@ -148,12 +148,12 @@ describe Unsplash::Photo do
       end
     end
 
-    it "raises on error" do
+    it "raises UnauthorizedError when not logged in" do
       VCR.use_cassette("photos") do
         photo = Unsplash::Photo.new(id: "abc123")
         expect {
           photo.like!
-        }.to raise_error Unsplash::Error
+        }.to raise_error Unsplash::UnauthorizedError
       end
     end
   end
@@ -170,12 +170,12 @@ describe Unsplash::Photo do
       end
     end
 
-    it "raises on error" do
+    it "raises UnauthorizedError when not logged in" do
       VCR.use_cassette("photos") do
         photo = Unsplash::Photo.new(id: "abc123")
         expect {
           photo.unlike!
-        }.to raise_error Unsplash::Error
+        }.to raise_error Unsplash::UnauthorizedError
       end
     end
   end

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -21,7 +21,7 @@ describe Unsplash::User do
         VCR.use_cassette("users") do
           @user = Unsplash::User.find(fake)
         end
-      }.to raise_error Unsplash::Error
+      }.to raise_error Unsplash::NotFoundError
     end
   end
 
@@ -104,7 +104,7 @@ describe Unsplash::User do
         VCR.use_cassette("users") do
           @user = Unsplash::User.find(fake).photos
         end
-      }.to raise_error Unsplash::Error
+      }.to raise_error Unsplash::NotFoundError
     end
   end
 

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -146,7 +146,7 @@ describe Unsplash::User do
           VCR.use_cassette("users", match_requests_on: [:auth_header, :path, :query]) do
             @user = Unsplash::User.current
           end
-        }.to raise_error Unsplash::Error
+        }.to raise_error Unsplash::UnauthorizedError
       end
     end
 
@@ -167,7 +167,7 @@ describe Unsplash::User do
           VCR.use_cassette("users", match_requests_on: [:headers, :path, :query]) do
             @user = Unsplash::User.update_current last_name: "Jangly"
           end
-        }.to raise_error Unsplash::Error
+        }.to raise_error Unsplash::UnauthorizedError
       end
     end
 


### PR DESCRIPTION
We have only a single `Unsplash::Error` class right now. Split that up into others depending on response code.