### PR TITLE
Loosen http party version to 0.16

### DIFF
--- a/unsplash.gemspec
+++ b/unsplash.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "httparty", "~> 0.16.4"
+  spec.add_dependency "httparty", "~> 0.16"
   spec.add_dependency "oauth2",   "~> 1"
 
   spec.add_development_dependency "rake",    "~> 12.3.2"


### PR DESCRIPTION
`httparty` gem has been upgraded in #62 to `0.16.4`, however, Unsplash client would still work with `0.16` assuming it follows semantic versioning. This PR loosens the requirement to `0.16` to make it compatible with other dependencies an app may have.