### PR TITLE
Add utm parameters to 'links' URLs

### DIFF
--- a/lib/unsplash/client.rb
+++ b/lib/unsplash/client.rb
@@ -39,6 +39,18 @@ module Unsplash # :nodoc:
       self.class.connection
     end
 
+    # @private
+    def add_utm_params(url)
+      uri = URI.parse(url)
+
+      qs = Rack::Utils.parse_nested_query(uri.query)
+      qs.merge!(connection.utm_params)
+
+      uri.query = Rack::Utils.build_query(qs)
+
+      uri.to_s
+    end
+
     class << self
       # The connection object being used to communicate with Unsplash.
       # @return [Unsplash::Connection] the connection

--- a/lib/unsplash/client.rb
+++ b/lib/unsplash/client.rb
@@ -7,6 +7,7 @@ module Unsplash # :nodoc:
     # @param attrs [Hash]
     def initialize(attrs = {})
       @attributes = OpenStruct.new(attrs)
+      add_utm_to_links
     end
 
     # (Re)load full object details from Unsplash.
@@ -49,6 +50,13 @@ module Unsplash # :nodoc:
       uri.query = Rack::Utils.build_query(qs)
 
       uri.to_s
+    end
+
+    # @private
+    def add_utm_to_links
+      (@attributes["links"] || {}).each do |key, url|
+        @attributes["links"][key] = add_utm_params(url)
+      end
     end
 
     class << self

--- a/lib/unsplash/connection.rb
+++ b/lib/unsplash/connection.rb
@@ -94,6 +94,14 @@ module Unsplash #:nodoc:
       request :delete, path, params
     end
 
+    def utm_params
+      {
+        "utm_source"   => Unsplash.configuration.utm_source || "api_app",
+        "utm_medium"   => "referral",
+        "utm_campaign" => "api-credit"
+      }
+    end
+
     private
 
     def request(verb, path, params = {})
@@ -148,14 +156,6 @@ module Unsplash #:nodoc:
 
     def public_auth_header
       { "Authorization" => "Client-ID #{@application_access_key}" }
-    end
-
-    def utm_params
-      {
-        utm_source:   Unsplash.configuration.utm_source || "api_app",
-        utm_medium:   "referral",
-        utm_campaign: "api-credit"
-      }
     end
 
     def refresh_token!

--- a/lib/unsplash/connection.rb
+++ b/lib/unsplash/connection.rb
@@ -102,7 +102,7 @@ module Unsplash #:nodoc:
       params.merge!(utm_params)
 
       if !Unsplash.configuration.utm_source
-        url = "https://community.unsplash.com/developersblog/unsplash-api-guidelines"
+        url = "https://help.unsplash.com/api-guidelines/unsplash-api-guidelines"
         Unsplash.configuration.logger.warn "utm_source is required as part of API Terms: #{url}"
       end
 

--- a/lib/unsplash/photo.rb
+++ b/lib/unsplash/photo.rb
@@ -3,6 +3,11 @@ module Unsplash # :nodoc:
   # Unsplash Photo operations.
   class Photo < Client
 
+    def initialize(attrs)
+      super
+      add_utm_to_urls
+    end
+
     # Like a photo for the current user.
     # @return [Boolean] True if successful. Will raise on error.
     def like!
@@ -21,6 +26,12 @@ module Unsplash # :nodoc:
     # @return [String] URL of image file for download.
     def track_download
       connection.get(links.download_location)["url"]
+    end
+
+    def add_utm_to_urls
+      (@attributes["urls"] || {}).each do |key, url|
+        @attributes["urls"][key] = add_utm_params(url)
+      end
     end
 
     class << self
@@ -100,7 +111,6 @@ module Unsplash # :nodoc:
       def parse_list(json)
         JSON.parse(json).map { |photo| new photo }
       end
-
     end
   end
 end

--- a/lib/unsplash/user.rb
+++ b/lib/unsplash/user.rb
@@ -88,11 +88,5 @@ module Unsplash # :nodoc:
         Unsplash::Collection.new collection.to_hash
       end
     end
-
-    # Get the URL of the user's Unsplash profile.
-    # @return [String] A URL.
-    def profile_url
-      add_utm_params("https://unsplash.com/@#{username}")
-    end
   end
 end

--- a/lib/unsplash/user.rb
+++ b/lib/unsplash/user.rb
@@ -89,5 +89,10 @@ module Unsplash # :nodoc:
       end
     end
 
+    # Get the URL of the user's Unsplash profile.
+    # @return [String] A URL.
+    def profile_url
+      add_utm_params("https://unsplash.com/@#{username}")
+    end
   end
 end

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -32,9 +32,9 @@ describe Unsplash::Connection do
       headers = { "Authorization"=> "Client-ID #{Unsplash.configuration.application_access_key}" }
       params = {
         foo: "bar",
-        utm_source:   "my_app",
-        utm_medium:   "referral",
-        utm_campaign: "api-credit"
+        "utm_source" => "my_app",
+        "utm_medium" =>  "referral",
+        "utm_campaign" => "api-credit"
       }
 
       Unsplash.configuration.utm_source = "my_app"


### PR DESCRIPTION
#### Overview

- Closes #69 
- Closes #71

Fix an old dead link to API guidelines. Object 'links' list gets utm params automatically appended.