### PR TITLE
Warn when calling Photo#random with both collections and query params

### DIFF
--- a/lib/unsplash/photo.rb
+++ b/lib/unsplash/photo.rb
@@ -46,7 +46,7 @@ module Unsplash # :nodoc:
       end
 
       # Get a random photo or set of photos. The photo selection pool can be narrowed using
-      # a combination of optional parameters. Can also optionally specify a custom image size.
+      # a combination of optional parameters.
       # @param count [Integer] Number of photos required. Default=1, Max=30
       # @param featured [Boolean] Limit selection to featured photos.
       # @param user [String] Limit selection to given User's ID.
@@ -55,6 +55,8 @@ module Unsplash # :nodoc:
       # @return [Unsplash::Photo] An Unsplash Photo if count parameter is omitted
       # @return [Array] An array of Unsplash Photos if the count parameter is specified. An array is returned even if count is 1
       def random(count: nil, collections: nil, featured: nil, user: nil, query: nil, orientation: nil)
+        Unsplash.configuration.logger.warn "You cannot combine 'collections' and 'query' parameters. 'query' will be ignored." if collections && query
+
         params = {
           collections: (collections && collections.join(",")),
           featured: featured,

--- a/spec/lib/photo_spec.rb
+++ b/spec/lib/photo_spec.rb
@@ -81,6 +81,13 @@ describe Unsplash::Photo do
       end
     end
 
+    it "logs warning when supplying both collections and query filters" do
+      allow(Unsplash::Photo.connection).to receive(:get).and_return(double(body: '{ "id": "definitely_a_photo" }'))
+      allow(Unsplash.configuration.logger).to receive(:warn).and_call_original
+
+      Unsplash::Photo.random(collections: [4,5,6], query: "cute dogs")
+      expect(Unsplash.configuration.logger).to have_received(:warn)
+    end
   end
 
   describe "#search" do


### PR DESCRIPTION
#### Overview

- Closes #67

The API doesn't support choosing a random photo with *both* a collections filter and a search query; when you try, `query` gets ignored. This is expected behaviour, so just log a warning.